### PR TITLE
Smooth turning towards new goal

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ To run, give the following command:
 
 Please refer to [the move_basic wiki page](http://wiki.ros.org/move_basic) for node documentation.
 
+New parameters:
+
+`~smooth_follow`: (bool) Toggle preserving velocity when rotating towards a new goal for smooth cornering. May be a bit less accurate, but a lot easier on the wheels.  Default False.
+
+
 ## New obstacle avoidance behavoir (March 2019)
 
 New behavior was added in the `side_dist` branch.  The behavior is to

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ New parameters:
 
 `~smooth_follow`: (bool) Toggle preserving velocity when rotating towards a new goal for smooth cornering. May be a bit less accurate, but a lot easier on the wheels.  Default False.
 
+`~forward_obstacle_threshold`: (float) Velocity multiplier for stopping when an obstacle is detected. Higher values should result in earlier braking. Default 1.5.
+
 
 ## New obstacle avoidance behavoir (March 2019)
 

--- a/src/move_basic.cpp
+++ b/src/move_basic.cpp
@@ -78,6 +78,8 @@ class MoveBasic {
     bool verboseInfo;
     bool smoothFollow;
 
+    double smoothBreakingMin;
+    double smoothBreakingMax; 
     double prevSmoothVelocity;
 
     double maxAngularVelocity;
@@ -279,6 +281,8 @@ MoveBasic::MoveBasic(): tfBuffer(ros::Duration(30.0)),
     nh.param<bool>("verbose_info", verboseInfo, false);
 
     nh.param<bool>("smooth_follow", smoothFollow, false);
+    nh.param<double>("smooth_breaking_min", smoothBreakingMin, 0.005);
+    nh.param<double>("smooth_breaking_max", smoothBreakingMax, 0.0075);
 
     prevSmoothVelocity = 0;
 
@@ -699,7 +703,8 @@ bool MoveBasic::rotate(double yaw, std::string drivingFrame)
             if (forwardObstacleDist <= prevSmoothVelocity * forwardObstacleThreshold) {
                 prevSmoothVelocity = 0;
             } else {
-                prevSmoothVelocity -= 0.007;
+                double factor = std::min(std::abs(yaw)/2.0,1.0);
+                prevSmoothVelocity -= smoothBreakingMin + (smoothBreakingMax - smoothBreakingMin) * factor;
                 if (prevSmoothVelocity < 0) {
                     prevSmoothVelocity = 0;
                 }


### PR DESCRIPTION
Added parameter toggleable smooth cornering as seen [here](https://drive.google.com/file/d/13ho4MqTTbJDcw6dd5NiNO5tKzmKEnl5f/view).

Upon receiving a new goal the linear velocity is preserved for a short time to prevent sudden stops at high speed that degrade wheel gears and spill cargo. Theoretically it should reduce accuracy a bit, though I haven't observed anything drastic during testing so far. It's safe to say that I haven't covered even close to all edge cases though.

It should stop once an obstacle is found during the time of slowdown, however I don't have a sonar board on hand to test that part out. 