### PR TITLE
Fix travis build error due to old python version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: true
 dist: trusty
 language: python
 python:
-  - "3.4"
+  - "3.6"
 env:
   global:
     - JOB_PATH=/tmp/devel_job
@@ -31,4 +31,4 @@ install:
   - sh devel_job.sh -y
 script:
   # get summary of test results
-  - /tmp/catkin/bin/catkin_test_results $JOB_PATH/catkin_workspace/test_results --all
+  - /tmp/catkin/bin/catkin_test_results $JOB_PATH/ws/test_results --all


### PR DESCRIPTION
ros_buildfarm needs a newer version of python, so we have travis provide
that.

Related to https://github.com/UbiquityRobotics/ubiquity_main/issues/239