### PR TITLE
Using planning frame from goal.

### DIFF
--- a/src/move_basic.cpp
+++ b/src/move_basic.cpp
@@ -264,7 +264,7 @@ MoveBasic::MoveBasic(): tfBuffer(ros::Duration(3.0)),
                       reverseWithoutTurningThreshold, 0.5);
 
     nh.param<std::string>("preferred_planning_frame",
-                          preferredPlanningFrame, "goal");
+                          preferredPlanningFrame, "");
     nh.param<std::string>("alternate_planning_frame",
                           alternatePlanningFrame, "odom");
     nh.param<std::string>("preferred_driving_frame",
@@ -413,8 +413,8 @@ void MoveBasic::executeAction(const move_base_msgs::MoveBaseGoalConstPtr& msg)
     // The pose of the robot planning frame MUST be known initially, and may or may not
     // be known after that.
     // The pose of the robot in the driving frame MUST be known at all times.
-    // A planning frame of "goal" means to use what ever frame the goal is specified in.
-    if (preferredPlanningFrame == "goal") {
+    // An empty planning frame means to use what ever frame the goal is specified in.
+    if (preferredPlanningFrame == "") {
        planningFrame = frameId;
        goalInPlanning = goal;
        ROS_INFO("Planning in goal frame: %s\n", planningFrame.c_str());

--- a/src/move_basic.cpp
+++ b/src/move_basic.cpp
@@ -643,13 +643,6 @@ bool MoveBasic::rotate(double yaw, const std::string& planningFrame,
         ros::spinOnce();
         r.sleep();
 
-        // Try to update goal - see comment in moveLinear()
-        tf2::Transform T_planning_driving;
-        tf2::Transform goalInDriving;
-        if (getTransform(planningFrame, drivingFrame, T_planning_driving)) {
-            goalInDriving = T_planning_driving * goalInPlanning;
-        }
-
         double x, y, currentYaw;
         tf2::Transform poseDriving;
         if (!getTransform(baseFrame, drivingFrame, poseDriving)) {

--- a/src/move_basic.cpp
+++ b/src/move_basic.cpp
@@ -269,7 +269,7 @@ MoveBasic::MoveBasic(): tfBuffer(ros::Duration(3.0)),
                           alternatePlanningFrame, "odom");
     nh.param<std::string>("preferred_driving_frame",
                           preferredDrivingFrame, "map");
-    nh.param<std::string>("alternate_planning_frame",
+    nh.param<std::string>("alternate_driving_frame",
                           alternateDrivingFrame, "odom");
     nh.param<std::string>("base_frame", baseFrame, "base_footprint");
 
@@ -493,8 +493,8 @@ void MoveBasic::executeAction(const move_base_msgs::MoveBaseGoalConstPtr& msg)
     }
 
     tf2::Vector3 linear = goalInBase.getOrigin();
-    // Don't use linear.length() because z is not relevant
-    double dist = sqrt(linear.x() * linear.x() + linear.y() * linear.y());
+    linear.setZ(0);
+    double dist = linear.length();
     bool reverseWithoutTurning =
         (reverseWithoutTurningThreshold > dist && linear.x() < 0.0);
 
@@ -730,7 +730,8 @@ bool MoveBasic::moveLinear(tf2::Transform& goalInDriving,
 
     tf2::Vector3 linear = (poseDrivingInitial.getOrigin() -
                            goalInDriving.getOrigin());
-    double requestedDistance = sqrt(linear.x() * linear.x() + linear.y() * linear.y());
+    linear.setZ(0);
+    double requestedDistance = linear.length();
 
     tf2::Transform poseDriving;
     if (!getTransform(drivingFrame, baseFrame, poseDriving)) {


### PR DESCRIPTION
If the planning frame is set to "goal", then the frame from the goal is used for planning.
This allows goals to be specified in arbitraty frames, such as 'fid104', meaning relative to the current observation of that fiducial. 

During movement, we attempt to update the goal in the driving frame based on the tf from the planning frame to the driving frame, if it exists.  The rationale behind this is that the observations will become more accurate as we get closer, in the case above.