### PR TITLE
Smooth cornering without slipping or tipping over

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ find_package(catkin REQUIRED COMPONENTS
   sensor_msgs
   visualization_msgs
   move_base_msgs
-  nav_core
+  nav_core # If this gets removed, isNextGoalAvailable() was triggering on the first goal
 )
 
 # Generate messages in the 'msg' folder
@@ -22,8 +22,8 @@ add_message_files(
   FollowMode.msg
 )
 generate_messages(
-  DEPENDENCIES 
-  std_msgs 
+  DEPENDENCIES
+  std_msgs
 )
 
 catkin_package(INCLUDE_DIRS DEPENDS)
@@ -74,4 +74,3 @@ if(CATKIN_ENABLE_TESTING)
                 test/test_obstacle_points.cpp)
         target_link_libraries(obstacle_points_test ${catkin_LIBRARIES})
 endif()
-

--- a/src/move_basic.cpp
+++ b/src/move_basic.cpp
@@ -844,12 +844,17 @@ bool MoveBasic::moveLinear(tf2::Transform& goalInDriving,
             velocity = 0;
         }
 
-        if (abs(remaining.x()) < linearTolerance) {
-            velocity = 0;
-            done = true;
-            ROS_INFO("MoveBasic: Done linear, error %f, %f meters",
-                     remaining.x(), remaining.y());
-        }
+	if (distTravelled >= requestedDistance) {
+		if (distRemaining > linearTolerance) {
+			abortGoal("MoveBasic: Aborting due to linear error");
+		}
+		else { 
+			velocity = 0;
+			done = true;
+        		ROS_INFO("MoveBasic: Done linear, error %f, %f meters", remaining.x(), remaining.y());
+		}
+	}
+
         if (!forward) {
             velocity = -velocity;
         }

--- a/src/move_basic.cpp
+++ b/src/move_basic.cpp
@@ -30,7 +30,6 @@
  */
 
 #include <ros/ros.h>
-#include <tf/transform_datatypes.h>
 #include <tf2/LinearMath/Transform.h>
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
@@ -41,7 +40,6 @@
 #include <geometry_msgs/Vector3.h>
 #include <nav_msgs/Path.h>
 #include <std_msgs/Float32.h>
-#include <move_basic/FollowMode.h>
 
 #include <actionlib/server/simple_action_server.h>
 #include <move_base_msgs/MoveBaseAction.h>
@@ -469,6 +467,7 @@ void MoveBasic::executeAction(const move_base_msgs::MoveBaseGoalConstPtr& msg)
 
         if (dist > linearTolerance) {
             double requestedYaw = atan2(linear.y(), linear.x());
+            ROS_INFO("REQUESTED YAW: %f", requestedYaw);
             if (reverseWithoutTurning) {
                 if (requestedYaw > 0.0) {
                     requestedYaw = -M_PI + requestedYaw;
@@ -512,15 +511,16 @@ void MoveBasic::executeAction(const move_base_msgs::MoveBaseGoalConstPtr& msg)
     }
 
     // Final rotation as specified in goal
-    tf2::Transform finalPose;
-    if (!getTransform(baseFrame, drivingFrame, finalPose)) {
-         abortGoal("MoveBasic: Cannot determine robot pose for final rotation");
-         return;
+    if (!actionServer->isNewGoalAvailable()) {
+        tf2::Transform finalPose;
+        if (!getTransform(baseFrame, drivingFrame, finalPose)) {
+             abortGoal("MoveBasic: Cannot determine robot pose for final rotation");
+             return;
+        }
+
+        getPose(finalPose, x, y, yaw);
+        rotate(goalYaw - yaw, drivingFrame);
     }
-
-    getPose(finalPose, x, y, yaw);
-    rotate(goalYaw - yaw, drivingFrame);
-
 /*
     sleep(10);
     // Final sanity check

--- a/src/move_basic.cpp
+++ b/src/move_basic.cpp
@@ -261,8 +261,6 @@ MoveBasic::MoveBasic(): tfBuffer(ros::Duration(3.0)),
 
     phGoalSub = nh.subscribe("/phantom", 1,
                             &MoveBasic::phantomGoalCallback, this);
-    // TODO: nextGoalSub = nh.subscribe("/move_base/goal", 1,
-    // TODO:                          &MoveBasic::nextGoalCallback, this);
 
     ros::NodeHandle actionNh("");
 
@@ -314,7 +312,7 @@ bool MoveBasic::transformPose(const std::string& from, const std::string& to,
 
 void MoveBasic::phantomGoalCallback(const std_msgs::BoolConstPtr &msg)
 {
-    // TODO: ROS_INFO("In the phantom Callback");
+    ROS_INFO("In the phantom Callback");
     phantomGoalReceived = msg->data;
     if (phantomGoalReceived) {
         phantom = true;
@@ -381,34 +379,6 @@ void MoveBasic::goalCallback(const geometry_msgs::PoseStamped::ConstPtr &msg)
         nextGoalAvailable = true;
     }
 }
-
-/*
-void MoveBasic::nextGoalCallback(const move_base_msgs::MoveBaseActionGoalConstPtr& msg)
-{
-    // isNewGoalAvailable() needs to update on an actionServer
-    std::condition_variable newgoal_cv;
-    std::mutex cv_m;
-    std::unique_lock<std::mutex> newgoal_lk(cv_m);
-    auto now = std::chrono::system_clock::now();
-    auto timeout = std::chrono::milliseconds(50);
-    newgoal_cv.wait_until(newgoal_lk,
-            now + timeout,
-            [this](){return actionServer->isNewGoalAvailable();}
-    );
-
-    // If there is a new goal store it
-    if(actionServer-> isNewGoalAvailable()) {
-        ROS_INFO("MoveBasic: Next goal received");
-        tf2::fromMsg(msg->goal.target_pose.pose, nextGoalPose);
-        frameIdNext = msg->goal.target_pose.header.frame_id;
-        // Needed for RobotCommander
-        if (frameIdNext[0] == '/')
-            frameIdNext = frameIdNext.substr(1);
-
-        nextGoalAvailable = true;
-    }
-}
-*/
 
 // Abort goal and print message
 
@@ -744,7 +714,7 @@ bool MoveBasic::smoothControl(double requestedDistance,
             if (actionServer->isPreemptRequested() && phantomGoalReceived) {
                 ROS_INFO("MoveBasic: Preempting phantom goal");
                 phantomGoalReceived = false;
-                // TODO: ROS_INFO("In the phantom preempt");
+                ROS_INFO("In the phantom preempt");
                 actionServer->setPreempted();
                 done = false;
                 goto FinishWithoutStop;
@@ -752,7 +722,7 @@ bool MoveBasic::smoothControl(double requestedDistance,
 
             if (actionServer->isPreemptRequested()) {
                 ROS_INFO("MoveBasic: Stopping due to preempt request");
-                // TODO: ROS_INFO("In the non phantom preempt");
+                ROS_INFO("In the non phantom preempt");
                 phantomGoalReceived = false;
                 actionServer->setPreempted();
                 done = false;

--- a/src/move_basic.cpp
+++ b/src/move_basic.cpp
@@ -88,7 +88,6 @@ class MoveBasic {
     bool nextGoalAvailable;
     tf2::Transform nextGoalPose;
     std::string frameIdNext;
-    std::string goalReachedFrameId;
 
     double lateralKp;
     double lateralKi;
@@ -188,7 +187,7 @@ MoveBasic::MoveBasic(): tfBuffer(ros::Duration(3.0)),
     nh.param<double>("angular_acceleration", maxAngularAcceleration, 5.0);
     nh.param<double>("max_linear_velocity", maxLinearVelocity, 1.1);
     nh.param<double>("linear_acceleration", maxLinearAcceleration, 1.1);
-    nh.param<double>("linear_tolerance", linearTolerance, 0.1);
+    nh.param<double>("linear_tolerance", linearTolerance, 0.15);
 
     // Parameters for turn PID
     nh.param<double>("lateral_kp", lateralKp, 4.0);
@@ -227,7 +226,6 @@ MoveBasic::MoveBasic(): tfBuffer(ros::Duration(3.0)),
     nh.param<double>("velocity_threshold", velThreshold, 0.01);
     nh.param<double>("velocity_multiplier", velMult, 1.0);
 
-    nh.param<std::string>("goal_reached_frame_id", goalReachedFrameId, "None");
     nh.param<std::string>("preferred_driving_frame",
                          preferredDrivingFrame, "map");
     nh.param<std::string>("alternate_driving_frame",
@@ -352,11 +350,6 @@ void MoveBasic::executeAction(const move_base_msgs::MoveBaseGoalConstPtr& msg)
     // Needed for RobotCommander
     if (frameId[0] == '/')
         frameId = frameId.substr(1);
-
-    if (frameId.compare(goalReachedFrameId) == 0) {
-        return;
-    }
-    goalReachedFrameId = frameId;
 
     double x, y, yaw;
     getPose(goal, x, y, yaw);
@@ -585,7 +578,7 @@ bool MoveBasic::smoothControl(double requestedDistance,
                                                         forwardLeft,
                                                         forwardRight);
             }
-            ROS_DEBUG("MoveBasic: %f L %f, R %f\n",
+            ROS_INFO("MoveBasic: %f L %f, R %f\n",
                     forwardObstacleDist, leftObstacleDist, rightObstacleDist);
 
             // Turning Algorithm that calculates the maximum allowed speed when cornering in order not to slip or tip over

--- a/src/move_basic.cpp
+++ b/src/move_basic.cpp
@@ -314,6 +314,7 @@ bool MoveBasic::transformPose(const std::string& from, const std::string& to,
 
 void MoveBasic::phantomGoalCallback(const std_msgs::BoolConstPtr &msg)
 {
+    // TODO: ROS_INFO("In the phantom Callback");
     phantomGoalReceived = msg->data;
     if (phantomGoalReceived) {
         phantom = true;
@@ -743,6 +744,7 @@ bool MoveBasic::smoothControl(double requestedDistance,
             if (actionServer->isPreemptRequested() && phantomGoalReceived) {
                 ROS_INFO("MoveBasic: Preempting phantom goal");
                 phantomGoalReceived = false;
+                // TODO: ROS_INFO("In the phantom preempt");
                 actionServer->setPreempted();
                 done = false;
                 goto FinishWithoutStop;
@@ -750,6 +752,7 @@ bool MoveBasic::smoothControl(double requestedDistance,
 
             if (actionServer->isPreemptRequested()) {
                 ROS_INFO("MoveBasic: Stopping due to preempt request");
+                // TODO: ROS_INFO("In the non phantom preempt");
                 phantomGoalReceived = false;
                 actionServer->setPreempted();
                 done = false;

--- a/src/move_basic.cpp
+++ b/src/move_basic.cpp
@@ -1,3 +1,4 @@
+
 /*
  * Copyright (c) 2017-9, Ubiquity Robotics
  * All rights reserved.
@@ -122,7 +123,7 @@ class MoveBasic {
 
     void phantomGoalCallback(const std_msgs::BoolConstPtr &msg);
     void goalCallback(const geometry_msgs::PoseStamped::ConstPtr &msg);
-    void nextGoalCallback(const move_base_msgs::MoveBaseActionGoalConstPtr& goal);
+    // TODO: void nextGoalCallback(const move_base_msgs::MoveBaseActionGoalConstPtr& goal);
     void executeAction(const move_base_msgs::MoveBaseGoalConstPtr& goal);
     void drawLine(double x0, double y0, double x1, double y1);
     void sendCmd(double angular, double linear);
@@ -260,8 +261,8 @@ MoveBasic::MoveBasic(): tfBuffer(ros::Duration(3.0)),
 
     phGoalSub = nh.subscribe("/phantom", 1,
                             &MoveBasic::phantomGoalCallback, this);
-    nextGoalSub = nh.subscribe("/move_base/goal", 1,
-                             &MoveBasic::nextGoalCallback, this);
+    // TODO: nextGoalSub = nh.subscribe("/move_base/goal", 1,
+    // TODO:                          &MoveBasic::nextGoalCallback, this);
 
     ros::NodeHandle actionNh("");
 
@@ -367,6 +368,7 @@ void MoveBasic::goalCallback(const geometry_msgs::PoseStamped::ConstPtr &msg)
     }
 }
 
+/*
 void MoveBasic::nextGoalCallback(const move_base_msgs::MoveBaseActionGoalConstPtr& msg)
 {
     // isNewGoalAvailable() needs to update on an actionServer
@@ -392,7 +394,7 @@ void MoveBasic::nextGoalCallback(const move_base_msgs::MoveBaseActionGoalConstPt
         nextGoalAvailable = true;
     }
 }
-
+*/
 
 // Abort goal and print message
 

--- a/src/move_basic.cpp
+++ b/src/move_basic.cpp
@@ -113,6 +113,7 @@ class MoveBasic {
     tf2::Vector3 forwardRight;
 
     void goalCallback(const geometry_msgs::PoseStamped::ConstPtr &msg);
+    void nextGoalCallback(const move_base_msgs::MoveBaseGoalConstPtr& goal);
     void executeAction(const move_base_msgs::MoveBaseGoalConstPtr& goal);
     void drawLine(double x0, double y0, double x1, double y1);
     void sendCmd(double angular, double linear);
@@ -299,7 +300,10 @@ void MoveBasic::goalCallback(const geometry_msgs::PoseStamped::ConstPtr &msg)
     actionGoal.header.stamp = ros::Time::now();
     actionGoal.goal.target_pose = *msg;
     goalPub.publish(actionGoal);
+}
 
+void MoveBasic::nextGoalCallback(const move_base_msgs::MoveBaseGoalConstPtr& msg)
+{
     // isNewGoalAvailable() needs to update on an actionServer
     std::condition_variable newgoal_cv;
     std::mutex cv_m;
@@ -313,8 +317,9 @@ void MoveBasic::goalCallback(const geometry_msgs::PoseStamped::ConstPtr &msg)
 
     // If there is a new goal store it
     if(actionServer-> isNewGoalAvailable()) {
-        tf2::fromMsg(msg->pose, nextGoalPose);
-        frameIdNext = msg->header.frame_id;
+        ROS_INFO("MoveBasic: Next goal received");
+        tf2::fromMsg(msg->target_pose.pose, nextGoalPose);
+        frameIdNext = msg->target_pose.header.frame_id;
         // Needed for RobotCommander
         if (frameIdNext[0] == '/')
             frameIdNext = frameIdNext.substr(1);

--- a/src/move_basic.cpp
+++ b/src/move_basic.cpp
@@ -47,15 +47,13 @@
 #include "move_basic/collision_checker.h"
 #include "move_basic/queued_action_server.h"
 
+#include <assert.h>
 #include <string>
+#include <condition_variable>
+#include <mutex>
+#include <chrono>
 
 typedef actionlib::QueuedActionServer<move_base_msgs::MoveBaseAction> MoveBaseActionServer;
-
-enum {
-    DRIVE_STRAIGHT,
-    FOLLOW_LEFT,
-    FOLLOW_RIGHT
-};
 
 class MoveBasic {
   private:
@@ -65,7 +63,6 @@ class MoveBasic {
     ros::Publisher cmdPub;
     ros::Publisher pathPub;
     ros::Publisher obstacle_dist_pub;
-    ros::Publisher errorPub;
 
     std::unique_ptr<MoveBaseActionServer> actionServer;
     std::unique_ptr<CollisionChecker> collision_checker;
@@ -74,48 +71,46 @@ class MoveBasic {
     tf2_ros::Buffer tfBuffer;
     tf2_ros::TransformListener listener;
 
-    double maxAngularVelocity;
-    double minAngularVelocity;
-    double angularAcceleration;
-    double angularTolerance;
-
-    double minLinearVelocity;
-    double maxLinearVelocity;
-    double linearAcceleration;
-    double linearTolerance;
-
-    // PID parameters for controlling lateral error
-    double lateralKp;
-    double lateralKi;
-    double lateralKd;
-    double lateralMaxRotation;
-
-    int rotationAttempts;
-    double localizationLatency;
-
-    double robotWidth;
-    double frontToLidar;
-    double obstacleWaitLimit;
-    
-    double previousRotation;
-
-    std::string preferredPlanningFrame;
-    std::string alternatePlanningFrame;
     std::string preferredDrivingFrame;
     std::string alternateDrivingFrame;
     std::string baseFrame;
 
-    double minSideDist;
+    double maxAngularVelocity;
+    double maxAngularAcceleration;
+    double maxLinearVelocity;
+    double maxLinearAcceleration;
+    double linearTolerance;
+
+    double maxIncline;
+    double gravityConstant;
     double maxLateralDev;
-    double maxAngularDev;
-    double sideRecoverWeight;
+
+    bool nextGoalAvailable;
+    tf2::Transform nextGoalPose;
+    std::string frameIdNext;
+
+    double lateralKp;
+    double lateralKi;
+    double lateralKd;
+
+    double abortTimeoutSecs;
+    double velMult;
+    double velThreshold;
+
+    double obstacleWaitLimit;
+    double forwardObstacleThreshold;
+
+    double minSideDist;
+    double minRequestDistance;
+    double angleRecoverWeight;
+
+    double reverseWithoutTurningThreshold;
 
     float forwardObstacleDist;
     float leftObstacleDist;
     float rightObstacleDist;
     tf2::Vector3 forwardLeft;
     tf2::Vector3 forwardRight;
-    double reverseWithoutTurningThreshold;
 
     void goalCallback(const geometry_msgs::PoseStamped::ConstPtr &msg);
     void executeAction(const move_base_msgs::MoveBaseGoalConstPtr& goal);
@@ -133,13 +128,10 @@ class MoveBasic {
 
     void run();
 
-    bool moveLinear(tf2::Transform& goalInDriving,
-                    const std::string& planningFrame,
-                    const std::string& drivingFrame);
-    bool rotate(double requestedYaw,
-                const std::string& drivingFrame);
-
-    tf2::Transform goalInPlanning;
+    bool smoothControl(double requestedDistance,
+                       bool reverseWithoutTurning,
+                       const std::string& drivingFrame,
+                       tf2::Transform& goalInDriving);
 };
 
 
@@ -158,24 +150,17 @@ static double deg2rad(double deg)
     return deg / 180.0 * M_PI;
 }
 
-// Get the sign of a number
-
-static int sign(double n)
-{
-    return (n <0 ? -1 : 1);
-}
-
-
 // Adjust angle to be between -PI and PI
 
 static void normalizeAngle(double& angle)
 {
-    if (angle < -M_PI) {
-         angle += 2 * M_PI;
-    }
-    if (angle > M_PI) {
+    if (angle < -M_PI)
+        angle += 2 * M_PI;
+        assert (angle > -M_PI);
+
+    if (angle > M_PI)
         angle -= 2 * M_PI;
-    }
+        assert (angle < M_PI);
 }
 
 
@@ -198,55 +183,51 @@ MoveBasic::MoveBasic(): tfBuffer(ros::Duration(3.0)),
                         listener(tfBuffer)
 {
     ros::NodeHandle nh("~");
-
-    nh.param<double>("min_angular_velocity", minAngularVelocity, 0.05);
-    nh.param<double>("max_angular_velocity", maxAngularVelocity, 1.0);
-    nh.param<double>("angular_acceleration", angularAcceleration, 0.3);
-    nh.param<double>("angular_tolerance", angularTolerance, 0.01);
-
-    nh.param<double>("min_linear_velocity", minLinearVelocity, 0.1);
-    nh.param<double>("max_linear_velocity", maxLinearVelocity, 0.5);
-    nh.param<double>("linear_acceleration", linearAcceleration, 0.25);
-    nh.param<double>("linear_tolerance", linearTolerance, 0.03);
+    nh.param<double>("max_angular_velocity", maxAngularVelocity, 2.0);
+    nh.param<double>("angular_acceleration", maxAngularAcceleration, 5.0);
+    nh.param<double>("max_linear_velocity", maxLinearVelocity, 1.1);
+    nh.param<double>("linear_acceleration", maxLinearAcceleration, 1.1);
+    nh.param<double>("linear_tolerance", linearTolerance, 0.15);
 
     // Parameters for turn PID
-    nh.param<double>("lateral_kp", lateralKp, 10.0);
+    nh.param<double>("lateral_kp", lateralKp, 4.0);
     nh.param<double>("lateral_ki", lateralKi, 0.0);
     nh.param<double>("lateral_kd", lateralKd, 0.0);
 
+    // To prevent sliping and tipping over when turning
+    nh.param<double>("max_incline_without_slipping", maxIncline, 0.005);
+    nh.param<double>("gravity_acceleration", gravityConstant, 9.81);
+    nh.param<double>("max_lateral_deviation", maxLateralDev, 0.4);
+
+    // After a goal is reached isNexGoalAvailable() on action server needs some time to update
+    // Afterwards in order to achieve smooth toggling between the goals a bool variable is set
+    nh.param<bool>("next_goal_available", nextGoalAvailable, false);
+
     // Minimum distance to maintain at each side
     nh.param<double>("min_side_dist", minSideDist, 0.3);
-
-    // Maximum deviation from linear path before aborting
-    nh.param<double>("max_lateral_deviation", maxLateralDev, 4.0);
-
-    // Maximum allowed deviation from straight path
-    nh.param<double>("max_angular_deviation", maxAngularDev, deg2rad(20.0));
-
-    // Maximum angular velocity during linear portion
-    nh.param<double>("max_lateral_rotation", lateralMaxRotation, 0.5);
+    nh.param<double>("minimum_requested_distance", minRequestDistance, 0.2);
 
     // Weighting of turning to recover from avoiding side obstacles
-    nh.param<double>("side_recover_weight", sideRecoverWeight, 0.3);
-
-    // how long to wait after moving to be sure localization is accurate
-    nh.param<double>("localization_latency", localizationLatency, 0.5);
-
-    nh.param<int>("rotation_attempts", rotationAttempts, 1);
+    nh.param<double>("side_recover_weight", angleRecoverWeight, 0.3);
 
     // how long to wait for an obstacle to disappear
     nh.param<double>("obstacle_wait_limit", obstacleWaitLimit, 10.0);
 
+    // if distance <  velocity times this we stop
+    nh.param<double>("forward_obstacle_threshold", forwardObstacleThreshold, 1.5);
+
     // Reverse distances for which rotation won't be performed
     nh.param<double>("reverse_without_turning_threshold",
-                      reverseWithoutTurningThreshold, 0.5);
+                        reverseWithoutTurningThreshold, 0.5);
 
-    nh.param<std::string>("preferred_planning_frame",
-                          preferredPlanningFrame, "");
-    nh.param<std::string>("alternate_planning_frame",
-                          alternatePlanningFrame, "odom");
+    nh.param<double>("abort_timeout", abortTimeoutSecs, 60.0);
+
+    // Proportional controller for following the goal
+    nh.param<double>("velocity_threshold", velThreshold, 0.01);
+    nh.param<double>("velocity_multiplier", velMult, 1.0);
+
     nh.param<std::string>("preferred_driving_frame",
-                          preferredDrivingFrame, "map");
+                         preferredDrivingFrame, "map");
     nh.param<std::string>("alternate_driving_frame",
                           alternateDrivingFrame, "odom");
     nh.param<std::string>("base_frame", baseFrame, "base_footprint");
@@ -256,15 +237,13 @@ MoveBasic::MoveBasic(): tfBuffer(ros::Duration(3.0)),
 
     obstacle_dist_pub =
         ros::Publisher(nh.advertise<geometry_msgs::Vector3>("/obstacle_distance", 1));
-    errorPub =
-        ros::Publisher(nh.advertise<geometry_msgs::Vector3>("/lateral_error", 1));
 
     goalSub = nh.subscribe("/move_base_simple/goal", 1,
                             &MoveBasic::goalCallback, this);
 
     ros::NodeHandle actionNh("");
 
-    actionServer.reset(new MoveBaseActionServer(actionNh, "move_base", 
+    actionServer.reset(new MoveBaseActionServer(actionNh, "move_base",
 	boost::bind(&MoveBasic::executeAction, this, _1)));
 
     actionServer->start();
@@ -294,19 +273,19 @@ bool MoveBasic::getTransform(const std::string& from, const std::string& to,
     }
 }
 
-// Transform a pose from one frame to another
+
+// Transform a pose from one frame to another, returns true on success
 
 bool MoveBasic::transformPose(const std::string& from, const std::string& to,
                               const tf2::Transform& in, tf2::Transform& out)
 {
     tf2::Transform tf;
-    if (!getTransform(from, to, tf)) {
+    if (!getTransform(from, to, tf))
         return false;
-    }
+
     out = tf * in;
     return true;
 }
-
 
 
 // Called when a simple goal message is received
@@ -314,12 +293,34 @@ bool MoveBasic::transformPose(const std::string& from, const std::string& to,
 void MoveBasic::goalCallback(const geometry_msgs::PoseStamped::ConstPtr &msg)
 {
     ROS_INFO("MoveBasic: Received simple goal");
+
     // send the goal to the action server
     move_base_msgs::MoveBaseActionGoal actionGoal;
     actionGoal.header.stamp = ros::Time::now();
     actionGoal.goal.target_pose = *msg;
-
     goalPub.publish(actionGoal);
+
+    // isNewGoalAvailable() needs to update on an actionServer
+    std::condition_variable newgoal_cv;
+    std::mutex cv_m;
+    std::unique_lock<std::mutex> newgoal_lk(cv_m);
+    auto now = std::chrono::system_clock::now();
+    auto timeout = std::chrono::milliseconds(50);
+    newgoal_cv.wait_until(newgoal_lk,
+            now + timeout,
+            [this](){return actionServer->isNewGoalAvailable();}
+    );
+
+    // If there is a new goal store it
+    if(actionServer-> isNewGoalAvailable()) {
+        tf2::fromMsg(msg->pose, nextGoalPose);
+        frameIdNext = msg->header.frame_id;
+        // Needed for RobotCommander
+        if (frameIdNext[0] == '/')
+            frameIdNext = frameIdNext.substr(1);
+
+        nextGoalAvailable = true;
+    }
 }
 
 
@@ -337,15 +338,9 @@ void MoveBasic::abortGoal(const std::string msg)
 void MoveBasic::executeAction(const move_base_msgs::MoveBaseGoalConstPtr& msg)
 {
     /*
-      Plan a path that involves rotating to face the goal, going straight towards it,
-      and then rotating for the final orientation.
-
       It is assumed that we are dealing with imperfect localization data:
          map->base_link is accurate but may be delayed and is at a slow rate
          odom->base_link is frequent, but drifts, particularly after rotating
-
-      To counter these issues, we plan in the map frame, and wait localizationLatency
-      after each step, and execute in the odom frame.
     */
 
     tf2::Transform goal;
@@ -358,45 +353,32 @@ void MoveBasic::executeAction(const move_base_msgs::MoveBaseGoalConstPtr& msg)
 
     double x, y, yaw;
     getPose(goal, x, y, yaw);
-
     ROS_INFO("MoveBasic: Received goal %f %f %f %s", x, y, rad2deg(yaw), frameId.c_str());
-
     if (std::isnan(yaw)) {
         abortGoal("MoveBasic: Aborting goal because an invalid orientation was specified");
         return;
     }
 
-    std::string planningFrame;
-    double goalYaw;
-
-    // The pose of the robot planning frame MUST be known initially, and may or may not
-    // be known after that.
-    // The pose of the robot in the driving frame MUST be known at all times.
-    // An empty planning frame means to use what ever frame the goal is specified in.
-    if (preferredPlanningFrame == "") {
-       planningFrame = frameId;
-       goalInPlanning = goal;
-       ROS_INFO("Planning in goal frame: %s\n", planningFrame.c_str());
-    }
-    else if (!transformPose(frameId, preferredPlanningFrame, goal, goalInPlanning)) {
-        ROS_WARN("MoveBasic: Will attempt to plan in %s frame", alternatePlanningFrame.c_str());
-        if (!transformPose(frameId, alternatePlanningFrame, goal,
-            goalInPlanning)) {
-            abortGoal("MoveBasic: No localization available for planning");
-            return;
-        }
-        planningFrame = alternatePlanningFrame;
-        goalYaw = yaw;
+    // Driving frame
+    std::string drivingFrame;
+    tf2::Transform goalInDriving;
+    tf2::Transform currentDrivingBase;
+    if (!getTransform(preferredDrivingFrame, baseFrame, currentDrivingBase)) {
+         ROS_WARN("MoveBasic: %s not available, attempting to drive using %s frame",
+                  preferredDrivingFrame.c_str(), alternateDrivingFrame.c_str());
+         if (!getTransform(alternateDrivingFrame,
+                           baseFrame, currentDrivingBase)) {
+             abortGoal("MoveBasic: Cannot determine robot pose in driving frame");
+             return;
+         }
+         else
+             drivingFrame = alternateDrivingFrame;
     }
     else {
-        planningFrame = preferredPlanningFrame;
+      drivingFrame = preferredDrivingFrame;
     }
 
-    getPose(goalInPlanning, x, y, goalYaw);
-    ROS_INFO("MoveBasic: Goal in %s  %f %f %f", planningFrame.c_str(),
-             x, y, rad2deg(goalYaw));
-
-    // publish our planned path
+    // Publish our planned path
     nav_msgs::Path path;
     geometry_msgs::PoseStamped p0, p1;
     path.header.frame_id = frameId;
@@ -407,7 +389,7 @@ void MoveBasic::executeAction(const move_base_msgs::MoveBaseGoalConstPtr& msg)
 
     tf2::Transform poseFrameId;
     if (!getTransform(baseFrame, frameId, poseFrameId)) {
-         abortGoal("MoveBasic: Cannot determine robot pose in goal frame(line 410)");
+         abortGoal("MoveBasic: Cannot determine robot pose in goal frame");
          return;
     }
     getPose(poseFrameId, x, y, yaw);
@@ -418,31 +400,12 @@ void MoveBasic::executeAction(const move_base_msgs::MoveBaseGoalConstPtr& msg)
 
     pathPub.publish(path);
 
-    std::string drivingFrame;
-    tf2::Transform goalInDriving;
-    tf2::Transform currentDrivingBase;
-    // Should be at time of goal message
-    if (!getTransform(preferredDrivingFrame, baseFrame, currentDrivingBase)) {
-         ROS_WARN("MoveBasic: %s not available, attempting to drive using %s frame",
-                  preferredDrivingFrame.c_str(), alternateDrivingFrame.c_str());
-         if (!getTransform(alternateDrivingFrame,
-                           baseFrame, currentDrivingBase)) {
-             abortGoal("MoveBasic: Cannot determine robot pose in driving frame(line 430)");
-             return;
-         }
-         else {
-             drivingFrame = alternateDrivingFrame;
-         }
-    }
-    else {
-      drivingFrame = preferredDrivingFrame;
-    }
 
+    // Current goal in driving frame
     if (!transformPose(frameId, drivingFrame, goal, goalInDriving)) {
-         abortGoal("MoveBasic: Cannot determine goal pose in driving frame(line 442)");
+         abortGoal("MoveBasic: Cannot determine goal pose in driving frame");
          return;
     }
-
     tf2::Transform goalInBase = currentDrivingBase * goalInDriving;
     {
        double x, y, yaw;
@@ -451,93 +414,26 @@ void MoveBasic::executeAction(const move_base_msgs::MoveBaseGoalConstPtr& msg)
              x, y, rad2deg(yaw));
     }
 
+    // Driving distance
     tf2::Vector3 linear = goalInBase.getOrigin();
-    linear.setZ(0);
-    double dist = linear.length();
-    bool reverseWithoutTurning =
-        (reverseWithoutTurningThreshold > dist && linear.x() < 0.0);
+    double requestedDistance = sqrt(linear.x() * linear.x() + linear.y() * linear.y());
 
-    // Initial rotation to face goal
-    for (int i=0; i<rotationAttempts; i++) {
-        tf2::Transform goalInBase;
-        if (!transformPose(frameId, baseFrame, goal, goalInBase)) {
-            ROS_WARN("MoveBasic: Cannot determine robot pose for rotation");
+    // Driving direction
+    bool reverseWithoutTurning = (reverseWithoutTurningThreshold > requestedDistance && linear.x() < 0.0);
+
+    // Send control commands
+    if (requestedDistance > minRequestDistance) {
+        if (!smoothControl(requestedDistance, reverseWithoutTurning, drivingFrame, goalInDriving))
             return;
-        }
-
-        if (dist > linearTolerance) {
-            double requestedYaw = atan2(linear.y(), linear.x());
-            ROS_INFO("REQUESTED YAW: %f", requestedYaw);
-            if (reverseWithoutTurning) {
-                if (requestedYaw > 0.0) {
-                    requestedYaw = -M_PI + requestedYaw;
-                }
-                else {
-                    requestedYaw = M_PI - requestedYaw;
-                }
-            }
-
-            if (std::abs(requestedYaw) < angularTolerance) {
-                break;
-            }
-            if (!rotate(requestedYaw, drivingFrame)) {
-                return;
-            }
-            sleep(localizationLatency);
-        }
     }
-
-    // Do linear portion of goal
-    ROS_INFO("MoveBasic: Requested distance %f", dist);
-
-    if (std::abs(dist) > linearTolerance) {
-        if (reverseWithoutTurning) {
-            dist = - dist;
-        }
-        if (!moveLinear(goalInDriving, planningFrame, drivingFrame)) {
-            return;
-        }
-        {
-            tf2::Transform poseFrameIdFinal;
-            if (!getTransform(baseFrame, frameId, poseFrameIdFinal)) {
-                 ROS_WARN("MoveBasic: Cannot determine robot pose in goal frame(line 502)");
-            }
-            tf2::Vector3 distTravelled = poseFrameIdFinal.getOrigin() -
-                                         poseFrameId.getOrigin();
-            ROS_DEBUG("MoveBasic: Travelled %f %f\n", distTravelled.x(), distTravelled.y());
-        }
-
-        sleep(localizationLatency);
+    else {
+        ROS_WARN("Requested distance is lower than the minimum distance threshold ( %f meters)", minRequestDistance);
+        abortGoal("MoveBasic: Aborting due to goal being already close enough.");
+        return;
     }
-
-    // Final rotation as specified in goal
-    if (!actionServer->isNewGoalAvailable()) {
-        tf2::Transform finalPose;
-        if (!getTransform(baseFrame, drivingFrame, finalPose)) {
-             abortGoal("MoveBasic: Cannot determine robot pose for final rotation");
-             return;
-        }
-
-        getPose(finalPose, x, y, yaw);
-        rotate(goalYaw - yaw, drivingFrame);
-    }
-/*
-    sleep(10);
-    // Final sanity check
-    {
-        tf2::Transform poseFrameIdFinal;
-        if (!getTransform(baseFrame, frameId, poseFrameIdFinal)) {
-             ROS_WARN("Cannot determine robot pose in goal frame");
-        }
-        tf2::Vector3 distTravelled = poseFrameIdFinal.getOrigin() -
-                                     poseFrameId.getOrigin();
-        ROS_DEBUG("Travelled %f %f\n", distTravelled.x(), distTravelled.y());
-    }
-*/
 
     actionServer->setSucceeded();
 }
-
 
 
 // Send a motion command
@@ -557,7 +453,6 @@ void MoveBasic::sendCmd(double angular, double linear)
 void MoveBasic::run()
 {
     ros::Rate r(20);
-    std_msgs::Float32 msg;
 
     while (ros::ok()) {
         ros::spinOnce();
@@ -578,312 +473,224 @@ void MoveBasic::run()
 }
 
 
-// Rotate relative to current orientation
+// Smooth control drive
 
-bool MoveBasic::rotate(double yaw, const std::string& drivingFrame)
+bool MoveBasic::smoothControl(double requestedDistance,
+                              bool reverseWithoutTurning,
+                              const std::string& drivingFrame,
+                              tf2::Transform& goalInDriving)
 {
-    ROS_INFO("MoveBasic: Requested rotation %f", rad2deg(yaw));
+        // Driving direction
+        bool forward = true;
 
-    tf2::Transform poseDriving;
-    if (!getTransform(baseFrame, drivingFrame, poseDriving)) {
-         abortGoal("MoveBasic: Cannot determine robot pose for rotation");
-         return false;
-    }
+        // For Abort check
+        ros::Time last = ros::Time::now();
+        ros::Duration abortTimeout(abortTimeoutSecs);
 
-    double x, y, currentYaw;
-    getPose(poseDriving, x, y, currentYaw);
-    double requestedYaw = currentYaw + yaw;
-    normalizeAngle(requestedYaw);
+        // For de/acceleration constraint
+        double previousLinearVelocity = 0.0;
+        double prevDistance = requestedDistance;
+        ros::Time previousTime = ros::Time::now();
 
-    bool done = false;
-    ros::Rate r(50);
+        // For lateral control
+        double lateralIntegral = 0.0;
+        double lateralError = 0.0;
+        double prevLateralError = 0.0;
+        double lateralDiff = 0.0;
 
-    int oscillations = 0;
-    double prevAngleRemaining = 0;
+        // For Obstacle Avoidance
+        bool waitingForObstacle = false;
+        int  waitingLoops = 0;
+        ros::Time obstacleTime;
 
-    while (!done && ros::ok()) {
-        ros::spinOnce();
-        r.sleep();
+        bool done = false;
+        ros::Rate r(50);
 
-	// TODO: Already defined?
-        // TODO: double x, y, currentYaw;
-        // TODO: tf2::Transform poseDriving;
-        if (!getTransform(baseFrame, drivingFrame, poseDriving)) {
-            abortGoal("MoveBasic: Cannot determine robot pose for rotation");
-            return false;
-        }
-        getPose(poseDriving, x, y, currentYaw);
+        while(!done && ros::ok()){
+            ros::spinOnce();
+            r.sleep();
 
-        double angleRemaining = requestedYaw - currentYaw;
-        normalizeAngle(angleRemaining);
-
-        double obstacle = collision_checker->obstacle_angle(angleRemaining > 0);
-        double remaining = std::min(std::abs(angleRemaining), std::abs(obstacle));
-        double speed = std::max(minAngularVelocity,
-            std::min(maxAngularVelocity,
-              std::sqrt(2.0 * angularAcceleration *
-                (remaining - angularTolerance))));
-
-        double angular_velocity = 0;
-
-        if (angleRemaining < 0.0) {
-            angular_velocity = -speed;
-        }
-        else {
-            angular_velocity = speed;
-        }
-
-        if (sign(prevAngleRemaining) != sign(angleRemaining)) {
-            oscillations++;
-        }
-        prevAngleRemaining = angleRemaining;
-
-        if (actionServer->isPreemptRequested()) {
-            ROS_INFO("MoveBasic: Stopping rotation due to preempt");
-            done = true;
-            angular_velocity = 0;
-        }
-
-        //ROS_INFO("%f %f %f", rad2deg(angleRemaining), angleRemaining, velocity);
-
-        if (std::abs(angleRemaining) < angularTolerance || oscillations > 2) {
-            angular_velocity = 0;
-            done = true;
-            ROS_INFO("MoveBasic: Done rotation, error %f degrees", rad2deg(angleRemaining));
-        }
-        sendCmd(angular_velocity, 0);
-    }
-    return done;
-}
-
-// Move forward specified distance
-
-bool MoveBasic::moveLinear(tf2::Transform& goalInDriving,
-                           const std::string& planningFrame,
-                           const std::string& drivingFrame)
-{
-    bool done = false;
-    ros::Rate r(50);
-
-    bool waitingForObstacle = false;
-    int  waitingLoops = 0;
-    double forwardObstacleThreshold = 1.5;  // if distance <  velocity times this we stop
-    ros::Time obstacleTime;
-
-    tf2::Transform poseDrivingInitial;
-    if (!getTransform(baseFrame, drivingFrame, poseDrivingInitial)) {
-         abortGoal("MoveBasic: Cannot determine robot pose for linear");
-         return false;
-    }
-
-    tf2::Vector3 linear = (poseDrivingInitial.getOrigin() -
-                           goalInDriving.getOrigin());
-    linear.setZ(0);
-    double requestedDistance = linear.length();
-
-    tf2::Transform poseDriving;
-    if (!getTransform(drivingFrame, baseFrame, poseDriving)) {
-         abortGoal("MoveBasic: Cannot determine robot pose for linear");
-         return false;
-    }
-
-    tf2::Transform goalInBase = poseDriving * goalInDriving;
-    tf2::Vector3 remaining = goalInBase.getOrigin();
-    bool forward = (remaining.x() > 0);
-
-    // For lateral control
-    double lateralIntegral = 0.0;
-    double lateralError = 0.0;
-    double prevLateralError = 0.0;
-    double lateralDiff = 0.0;
-    ros::Time sensorTime;
-
-    while (!done && ros::ok()) {
-        ros::spinOnce();
-        r.sleep();
-
-        // Try to update the goal in the driving frame. This might not work,
-        // for example if it was based on a fiducial which was no longer
-        // visible. However, if the goal was based up a fiducial, then it
-        // is likley that the estimate of our position relative to it
-        // will improve as we get closer
-        tf2::Transform T_planning_driving;
-        if (getTransform(planningFrame, drivingFrame, T_planning_driving)) {
-            goalInDriving = T_planning_driving * goalInPlanning;
-            double gx, gy, gyaw;
-            getPose(goalInDriving, gx, gy, gyaw);
-            ROS_DEBUG("Updated goal %f %f %f\n", gx, gy, gyaw);
-        }
-        else {
-            ROS_DEBUG("Could not update goal\n");
-        }
-
-        if (!getTransform("odom", baseFrame, poseDriving)) {
-             ROS_WARN("MoveBasic: Cannot determine robot pose for linear");
-             continue;
-        }
-        goalInBase = poseDriving * goalInDriving;
-        remaining = goalInBase.getOrigin();
-        double distRemaining = sqrt(remaining.x() * remaining.x() + remaining.y() * remaining.y());
-
-        tf2::Transform initialBaseToCurrent = poseDrivingInitial * poseDriving;
-        double cx, cy, cyaw;
-        getPose(initialBaseToCurrent, cx, cy, cyaw);
-
-        double distTravelled = std::abs(requestedDistance) - std::abs(distRemaining);
-
-
-        // stick to planned path
-        lateralError = sideRecoverWeight * remaining.y();
-     
-/*
-        Future enhancement: turn to avoid a forward obstacle
-
-        bool canTurn = std::abs(cyaw) <= maxTurn;
-        if (canTurn && forwardObstacleDist < 1.0) {
-            if (leftObstacleDist > rightObstacleDist) {
-               lateralError = lateralMaxRotation;
+            tf2::Transform poseDriving;
+            if (!getTransform(drivingFrame, baseFrame, poseDriving)) {
+                 ROS_WARN("MoveBasic: Cannot determine robot pose for driving");
+                 continue;
             }
-            else {
-               lateralError = -lateralMaxRotation;
+
+            // Current goal state in base frame
+            tf2::Transform goalInBase = poseDriving * goalInDriving;
+            tf2::Vector3 remaining = goalInBase.getOrigin();
+            double distRemaining = sqrt(remaining.x() * remaining.x() + remaining.y() * remaining.y());
+            ROS_INFO("distRemaining: %f", distRemaining);
+            double angleRemaining = atan2(remaining.y(), remaining.x());
+            normalizeAngle(angleRemaining);
+
+            // If the goal is right behing the robot, it drives backwards to it
+            if (reverseWithoutTurning) {
+                if (angleRemaining > 0.0)
+                    angleRemaining = -M_PI + angleRemaining;
+                else
+                    angleRemaining = M_PI - angleRemaining;
+                forward = false;
             }
-        }
-*/
-        if (std::abs(remaining.y()) >= maxLateralDev) {
-            abortGoal("MoveBasic: Aborting since max deviation reached");
-            sendCmd(0, 0);
-            return false;
-        }
 
-        // PID loop to control rotation to keep robot on path
-        double rotation = 0.0;
+            // Next goal state in base frame, if available
+            double angleToNextGoal;
+            double distanceToNextGoal;
+            if (nextGoalAvailable) {
+                tf2::Transform nextGoalInDriving;
+                // Next goal in driving frame
+                if (!transformPose(frameIdNext, drivingFrame, nextGoalPose, nextGoalInDriving)) {
+                     abortGoal("MoveBasic: Cannot determine next goal pose in driving frame");
+                     done = false;
+                     goto FinishWithStop;
+                }
+                tf2::Transform nextGoalInBase = poseDriving * nextGoalInDriving;
+                tf2::Vector3 nextRemaining = nextGoalInBase.getOrigin();
+                angleToNextGoal = atan2(nextRemaining.y(), nextRemaining.x());
+                normalizeAngle(angleToNextGoal);
+                distanceToNextGoal = sqrt(nextRemaining.x() * nextRemaining.x() + nextRemaining.y() * nextRemaining.y());
+            }
 
-        lateralDiff = lateralError - prevLateralError;
-        prevLateralError = lateralError;
 
-        lateralIntegral += lateralError;
+            // Control to reference pose //
 
-        rotation = (lateralKp * lateralError) + (lateralKi * lateralIntegral) +
-                   (lateralKd * lateralDiff);
+            // Rotational part
+            double pidAngularVelocity = 0.0;
+            lateralError = angleRecoverWeight * angleRemaining;
+            lateralDiff = lateralError - prevLateralError;
+            prevLateralError = lateralError;
+            lateralIntegral += lateralError;
+            pidAngularVelocity = (lateralKp * lateralError) + (lateralKi * lateralIntegral) +
+                       (lateralKd * lateralDiff);
 
-        // Clamp rotation
-        rotation = std::max(-lateralMaxRotation, std::min(lateralMaxRotation,
-                                                          rotation));
-	/*
-	// If goal passed, the orientation turns around
-	// TODO: Test it!
-	bool goal_passed = false;
-	double error_rotation = rotation - previousRotation;
-	if (error_rotation > 90 || error_rotation < 90) {
-		goal_passed = true;
-	}
-	*/
+            double obstacle = collision_checker->obstacle_angle(angleRemaining > 0);
+            double obstacleAngle = std::min(std::abs(angleRemaining), std::abs(obstacle));
+            double angularVelocity = std::max(-maxAngularVelocity,
+                                        std::min(maxAngularVelocity,
+                                        std::min(pidAngularVelocity, sqrt(2.0 * maxAngularAcceleration * obstacleAngle))));
 
-        // Limit angular deviation from planned path to prevent turning around
-        if (cyaw > maxAngularDev && rotation < 0) {
-            ROS_DEBUG("limit right\n");
-            rotation = 0;
-        }
-        else if (cyaw < -maxAngularDev && rotation > 0) {
-            ROS_DEBUG("limit left\n");
-            rotation = 0;
-        }
+            // Distance to obstacle
+            double obstacleDist = forwardObstacleDist;
+            if (requestedDistance < 0.0) { // Reverse
+                obstacleDist = collision_checker->obstacle_dist(false,
+                                                        leftObstacleDist,
+                                                        rightObstacleDist,
+                                                        forwardLeft,
+                                                        forwardRight);
+            }
+            ROS_INFO("MoveBasic: %f L %f, R %f\n",
+                    forwardObstacleDist, leftObstacleDist, rightObstacleDist);
 
-        ROS_DEBUG("MoveBasic: %f L %f, R %f %f %f %f %f %f\n",
-                  forwardObstacleDist, leftObstacleDist, rightObstacleDist,
-                  remaining.x(), remaining.y(), lateralError,
-                  rotation, rad2deg(cyaw));
+            // Turning Algorithm that calculates the maximum allowed speed when cornering in order not to slip or tip over
+            double maxTurnVelocity = sqrt(maxLateralDev * gravityConstant * maxIncline/(1-cos(angleRemaining/2)));
+            double linearVelocity = std::max(-maxLinearVelocity,
+                                        std::min(std::min(maxLinearVelocity,
+                                        std::min(std::min(velMult * distRemaining, maxTurnVelocity),
+                                        sqrt(2.0 * maxLinearAcceleration * obstacleDist))),
+                                        velMult * (previousLinearVelocity + 2.0 * maxLinearAcceleration * distRemaining)));
 
-        // Publish messages for PID tuning
-        geometry_msgs::Vector3 pid_debug;
-        pid_debug.x = remaining.x();
-        pid_debug.y = lateralError;
-        pid_debug.z = rotation;
-        errorPub.publish(pid_debug);
+            // In order to achieve smooth toggling between going linear and into the turn, minimum output velocity
+            // of the Turning Algorithm is calculated so that the linear velocity(going into the turn) does not get lower than that
+            if (nextGoalAvailable) {
+                double startTurnVelocity = sqrt(gravityConstant * maxIncline * maxLateralDev/(1-cos(angleToNextGoal/2)));
+                double nextGoalVelocity = velMult * distanceToNextGoal;
+                linearVelocity = std::min(nextGoalVelocity,
+                                    std::min(maxLinearVelocity,
+                                    std::max(linearVelocity, startTurnVelocity)));
+            }
 
-        double obstacleDist = forwardObstacleDist;
-        if (requestedDistance < 0.0) { // Reverse
-            obstacleDist = collision_checker->obstacle_dist(false,
-                                                            leftObstacleDist,
-                                                            rightObstacleDist,
-                                                            forwardLeft,
-                                                            forwardRight);
-        }
+            if (!forward)
+                linearVelocity = -linearVelocity;
 
-        double velocity = std::max(minLinearVelocity,
-            std::min(maxLinearVelocity, std::min(
-              std::sqrt(2.0 * linearAcceleration * std::abs(distTravelled)),
-              std::sqrt(0.5 * linearAcceleration *
-                 std::min(obstacleDist, distRemaining)))));
+            previousLinearVelocity = linearVelocity;
+            previousTime = ros::Time::now();
 
-        // Stop if there is an obstacle in the distance we would hit in given time
-        bool obstacleDetected = obstacleDist <= velocity * forwardObstacleThreshold;
-        if (obstacleDetected) {
-            velocity = 0;
-            if (!waitingForObstacle) {
-                ROS_INFO("MoveBasic: PAUSING for OBSTACLE");
-                obstacleTime = ros::Time::now();
-                waitingForObstacle = true;
+            // Send control command
+            sendCmd(angularVelocity, linearVelocity);
+
+
+            // Obstacle Avoidance //
+
+            // Stop if there is an obstacle in the distance we would hit in given time
+            bool obstacleDetected = (obstacleDist <= linearVelocity * forwardObstacleThreshold);
+            if (obstacleDetected) {
+                linearVelocity = 0;
+                if (!waitingForObstacle) {
+                    ROS_INFO("MoveBasic: PAUSING for OBSTACLE");
+                    obstacleTime = ros::Time::now();
+                    waitingForObstacle = true;
+                    waitingLoops = 0;
+                }
+                else {
+                    waitingLoops += 1;
+                    if ((waitingLoops % 10) == 1)
+                        ROS_INFO("MoveBasic: Still waiting for obstacle at %f meters!", obstacleDist);
+                    ros::Duration waitTime = ros::Time::now() - obstacleTime;
+                    if (waitTime.toSec() > obstacleWaitLimit) {
+                        abortGoal("MoveBasic: Aborting due to obstacle");
+                        done = false;
+                        goto FinishWithStop;
+                    }
+                }
+            }
+
+            if (waitingForObstacle && ! obstacleDetected) {
+                ROS_INFO("MoveBasic: Resuming after obstacle has gone");
+                waitingForObstacle = false;
                 waitingLoops = 0;
             }
-            else {
-                waitingLoops += 1;
-                if ((waitingLoops % 10) == 1) {
-                    ROS_INFO("MoveBasic: Still waiting for obstacle at %f meters!", obstacleDist);
-                }
-                ros::Duration waitTime = ros::Time::now() - obstacleTime;
-                if (waitTime.toSec() > obstacleWaitLimit) {
-                    abortGoal("MoveBasic: Aborting due to obstacle");
-                    sendCmd(0, 0);
-                    return false;
+
+
+            // Abort Checks //
+
+            if (distRemaining < prevDistance) {
+                prevDistance = distRemaining;
+                if (ros::Time::now() - last > abortTimeout) {
+                        abortGoal("MoveBasic: No progress towards goal for longer than timeout.");
+                        done = false;
+                        goto FinishWithStop;
                 }
             }
-        }
 
-        if (waitingForObstacle && ! obstacleDetected) {
-            ROS_INFO("MoveBasic: Resuming after obstacle has gone");
-            waitingForObstacle = false;
-            waitingLoops = 0;
-            // start off again smoothly
-            requestedDistance = distRemaining;
-            distTravelled = 0.0;
-        }
+            if (actionServer->isPreemptRequested()) {
+                ROS_INFO("MoveBasic: Stopping due to preempt request");
+                done = true;
+                goto FinishWithStop;
+            }
 
-        if (actionServer->isPreemptRequested()) {
-            ROS_INFO("MoveBasic: Stopping move due to preempt");
-            done = true;
-            velocity = 0;
-        }
 
-	// TODO: Motor controller speed command noise "???"
-        double velMult = 1.0; // TODO: Experimental variable
-	double MOTOR_CONTROLLER_NOISE = 0.001;
-	if (velMult*distRemaining < MOTOR_CONTROLLER_NOISE) { // Check if velocity input lower than the noise level
-		if (!(actionServer->isNewGoalAvailable()) && (distRemaining < linearTolerance)) { // Checks if in tolerance range
-			velocity = 0;
-			done = true;
-        		ROS_INFO("MoveBasic: Done linear, error %f, %f meters", remaining.x(), remaining.y());
-		}
-		/*
-		else if (actionServer->isNewGoalAvailable() && (distRemaining < linearTolerance || goal_passed)) {
-			// Keep the velocity
-			done = true;
-        		ROS_INFO("MoveBasic: Done linear, error %f, %f meters", remaining.x(), remaining.y());
-		}
-		*/
-		else {
-			velocity = 0;
-			done = false;
-			abortGoal("MoveBasic: Aborting due to linear error");
-		}
-	}
+            // Check navigation complete //
 
-        if (!forward) {
-            velocity = -velocity;
+            // Checks if intermediate reference pose reached
+            if (distRemaining < linearTolerance && nextGoalAvailable) { // Checks if in tolerance range
+                ROS_INFO("MoveBasic: Goal reached - ERROR: x: %f meters, y: %f meters, yaw: %f degrees", remaining.x(), remaining.y(), rad2deg(angleRemaining));
+                nextGoalAvailable = false;
+                done = true;
+                goto FinishWithoutStop;
+            }
+
+            // Checks if final reference pose reached
+            if ((std::abs(linearVelocity) < velThreshold) && !nextGoalAvailable && !waitingForObstacle && (prevDistance+linearTolerance < requestedDistance)) {
+                ROS_DEBUG("Remaining velocity: %f", linearVelocity);
+                sendCmd(0, 0);
+                nextGoalAvailable = false;
+                if (distRemaining < linearTolerance) { // Checks if in tolerance range
+                    ROS_INFO("MoveBasic: Goal reached - ERROR: x: %f meters, y: %f meters, yaw: %f degrees", remaining.x(), remaining.y(), rad2deg(angleRemaining));
+                    done = true;
+                }
+                else {
+                    abortGoal("MoveBasic: Aborting due to missing the goal");
+                    done = false;
+                }
+                goto FinishWithStop;
+            }
         }
-        sendCmd(rotation, velMult * velocity);
-    }
-    return done;
+   FinishWithStop:
+        sendCmd(0, 0);
+
+   FinishWithoutStop:
+
+   return done;
 }
 
 

--- a/src/move_basic.cpp
+++ b/src/move_basic.cpp
@@ -47,15 +47,13 @@
 #include "move_basic/collision_checker.h"
 #include "move_basic/queued_action_server.h"
 
+#include <assert.h>
 #include <string>
+#include <condition_variable>
+#include <mutex>
+#include <chrono>
 
 typedef actionlib::QueuedActionServer<move_base_msgs::MoveBaseAction> MoveBaseActionServer;
-
-enum {
-    DRIVE_STRAIGHT,
-    FOLLOW_LEFT,
-    FOLLOW_RIGHT
-};
 
 class MoveBasic {
   private:
@@ -65,7 +63,6 @@ class MoveBasic {
     ros::Publisher cmdPub;
     ros::Publisher pathPub;
     ros::Publisher obstacle_dist_pub;
-    ros::Publisher errorPub;
 
     std::unique_ptr<MoveBaseActionServer> actionServer;
     std::unique_ptr<CollisionChecker> collision_checker;
@@ -74,48 +71,47 @@ class MoveBasic {
     tf2_ros::Buffer tfBuffer;
     tf2_ros::TransformListener listener;
 
-    double maxAngularVelocity;
-    double minAngularVelocity;
-    double angularAcceleration;
-    double angularTolerance;
-
-    double minLinearVelocity;
-    double maxLinearVelocity;
-    double linearAcceleration;
-    double linearTolerance;
-
-    // PID parameters for controlling lateral error
-    double lateralKp;
-    double lateralKi;
-    double lateralKd;
-    double lateralMaxRotation;
-
-    int rotationAttempts;
-    double localizationLatency;
-
-    double robotWidth;
-    double frontToLidar;
-    double obstacleWaitLimit;
-    
-    double previousRotation;
-
-    std::string preferredPlanningFrame;
-    std::string alternatePlanningFrame;
     std::string preferredDrivingFrame;
     std::string alternateDrivingFrame;
     std::string baseFrame;
 
-    double minSideDist;
+    double maxAngularVelocity;
+    double maxAngularAcceleration;
+    double maxLinearVelocity;
+    double maxLinearAcceleration;
+    double linearTolerance;
+
+    double maxIncline;
+    double gravityConstant;
     double maxLateralDev;
-    double maxAngularDev;
-    double sideRecoverWeight;
+
+    bool nextGoalAvailable;
+    tf2::Transform nextGoalPose;
+    std::string frameIdNext;
+    std::string goalReachedFrameId;
+
+    double lateralKp;
+    double lateralKi;
+    double lateralKd;
+
+    double abortTimeoutSecs;
+    double velMult;
+    double velThreshold;
+
+    double obstacleWaitLimit;
+    double forwardObstacleThreshold;
+
+    double minSideDist;
+    double minRequestDistance;
+    double angleRecoverWeight;
+
+    double reverseWithoutTurningThreshold;
 
     float forwardObstacleDist;
     float leftObstacleDist;
     float rightObstacleDist;
     tf2::Vector3 forwardLeft;
     tf2::Vector3 forwardRight;
-    double reverseWithoutTurningThreshold;
 
     void goalCallback(const geometry_msgs::PoseStamped::ConstPtr &msg);
     void executeAction(const move_base_msgs::MoveBaseGoalConstPtr& goal);
@@ -133,13 +129,10 @@ class MoveBasic {
 
     void run();
 
-    bool moveLinear(tf2::Transform& goalInDriving,
-                    const std::string& planningFrame,
-                    const std::string& drivingFrame);
-    bool rotate(double requestedYaw,
-                const std::string& drivingFrame);
-
-    tf2::Transform goalInPlanning;
+    bool smoothControl(double requestedDistance,
+                       bool reverseWithoutTurning,
+                       const std::string& drivingFrame,
+                       tf2::Transform& goalInDriving);
 };
 
 
@@ -158,24 +151,17 @@ static double deg2rad(double deg)
     return deg / 180.0 * M_PI;
 }
 
-// Get the sign of a number
-
-static int sign(double n)
-{
-    return (n <0 ? -1 : 1);
-}
-
-
 // Adjust angle to be between -PI and PI
 
 static void normalizeAngle(double& angle)
 {
-    if (angle < -M_PI) {
-         angle += 2 * M_PI;
-    }
-    if (angle > M_PI) {
+    if (angle < -M_PI)
+        angle += 2 * M_PI;
+        assert (angle > -M_PI);
+
+    if (angle > M_PI)
         angle -= 2 * M_PI;
-    }
+        assert (angle < M_PI);
 }
 
 
@@ -198,55 +184,52 @@ MoveBasic::MoveBasic(): tfBuffer(ros::Duration(3.0)),
                         listener(tfBuffer)
 {
     ros::NodeHandle nh("~");
-
-    nh.param<double>("min_angular_velocity", minAngularVelocity, 0.05);
-    nh.param<double>("max_angular_velocity", maxAngularVelocity, 1.0);
-    nh.param<double>("angular_acceleration", angularAcceleration, 0.3);
-    nh.param<double>("angular_tolerance", angularTolerance, 0.01);
-
-    nh.param<double>("min_linear_velocity", minLinearVelocity, 0.1);
-    nh.param<double>("max_linear_velocity", maxLinearVelocity, 0.5);
-    nh.param<double>("linear_acceleration", linearAcceleration, 0.25);
-    nh.param<double>("linear_tolerance", linearTolerance, 0.03);
+    nh.param<double>("max_angular_velocity", maxAngularVelocity, 2.0);
+    nh.param<double>("angular_acceleration", maxAngularAcceleration, 5.0);
+    nh.param<double>("max_linear_velocity", maxLinearVelocity, 1.1);
+    nh.param<double>("linear_acceleration", maxLinearAcceleration, 1.1);
+    nh.param<double>("linear_tolerance", linearTolerance, 0.1);
 
     // Parameters for turn PID
-    nh.param<double>("lateral_kp", lateralKp, 10.0);
+    nh.param<double>("lateral_kp", lateralKp, 4.0);
     nh.param<double>("lateral_ki", lateralKi, 0.0);
     nh.param<double>("lateral_kd", lateralKd, 0.0);
 
+    // To prevent sliping and tipping over when turning
+    nh.param<double>("max_incline_without_slipping", maxIncline, 0.005);
+    nh.param<double>("gravity_acceleration", gravityConstant, 9.81);
+    nh.param<double>("max_lateral_deviation", maxLateralDev, 0.4);
+
+    // After a goal is reached isNexGoalAvailable() on action server needs some time to update
+    // Afterwards in order to achieve smooth toggling between the goals a bool variable is set
+    nh.param<bool>("next_goal_available", nextGoalAvailable, false);
+
     // Minimum distance to maintain at each side
     nh.param<double>("min_side_dist", minSideDist, 0.3);
-
-    // Maximum deviation from linear path before aborting
-    nh.param<double>("max_lateral_deviation", maxLateralDev, 4.0);
-
-    // Maximum allowed deviation from straight path
-    nh.param<double>("max_angular_deviation", maxAngularDev, deg2rad(20.0));
-
-    // Maximum angular velocity during linear portion
-    nh.param<double>("max_lateral_rotation", lateralMaxRotation, 0.5);
+    nh.param<double>("minimum_requested_distance", minRequestDistance, 0.2);
 
     // Weighting of turning to recover from avoiding side obstacles
-    nh.param<double>("side_recover_weight", sideRecoverWeight, 0.3);
-
-    // how long to wait after moving to be sure localization is accurate
-    nh.param<double>("localization_latency", localizationLatency, 0.5);
-
-    nh.param<int>("rotation_attempts", rotationAttempts, 1);
+    nh.param<double>("side_recover_weight", angleRecoverWeight, 0.3);
 
     // how long to wait for an obstacle to disappear
     nh.param<double>("obstacle_wait_limit", obstacleWaitLimit, 10.0);
 
+    // if distance <  velocity times this we stop
+    nh.param<double>("forward_obstacle_threshold", forwardObstacleThreshold, 1.5);
+
     // Reverse distances for which rotation won't be performed
     nh.param<double>("reverse_without_turning_threshold",
-                      reverseWithoutTurningThreshold, 0.5);
+                        reverseWithoutTurningThreshold, 0.5);
 
-    nh.param<std::string>("preferred_planning_frame",
-                          preferredPlanningFrame, "");
-    nh.param<std::string>("alternate_planning_frame",
-                          alternatePlanningFrame, "odom");
+    nh.param<double>("abort_timeout", abortTimeoutSecs, 60.0);
+
+    // Proportional controller for following the goal
+    nh.param<double>("velocity_threshold", velThreshold, 0.01);
+    nh.param<double>("velocity_multiplier", velMult, 1.0);
+
+    nh.param<std::string>("goal_reached_frame_id", goalReachedFrameId, "None");
     nh.param<std::string>("preferred_driving_frame",
-                          preferredDrivingFrame, "map");
+                         preferredDrivingFrame, "map");
     nh.param<std::string>("alternate_driving_frame",
                           alternateDrivingFrame, "odom");
     nh.param<std::string>("base_frame", baseFrame, "base_footprint");
@@ -256,15 +239,13 @@ MoveBasic::MoveBasic(): tfBuffer(ros::Duration(3.0)),
 
     obstacle_dist_pub =
         ros::Publisher(nh.advertise<geometry_msgs::Vector3>("/obstacle_distance", 1));
-    errorPub =
-        ros::Publisher(nh.advertise<geometry_msgs::Vector3>("/lateral_error", 1));
 
     goalSub = nh.subscribe("/move_base_simple/goal", 1,
                             &MoveBasic::goalCallback, this);
 
     ros::NodeHandle actionNh("");
 
-    actionServer.reset(new MoveBaseActionServer(actionNh, "move_base", 
+    actionServer.reset(new MoveBaseActionServer(actionNh, "move_base",
 	boost::bind(&MoveBasic::executeAction, this, _1)));
 
     actionServer->start();
@@ -294,19 +275,19 @@ bool MoveBasic::getTransform(const std::string& from, const std::string& to,
     }
 }
 
-// Transform a pose from one frame to another
+
+// Transform a pose from one frame to another, returns true on success
 
 bool MoveBasic::transformPose(const std::string& from, const std::string& to,
                               const tf2::Transform& in, tf2::Transform& out)
 {
     tf2::Transform tf;
-    if (!getTransform(from, to, tf)) {
+    if (!getTransform(from, to, tf))
         return false;
-    }
+
     out = tf * in;
     return true;
 }
-
 
 
 // Called when a simple goal message is received
@@ -314,12 +295,34 @@ bool MoveBasic::transformPose(const std::string& from, const std::string& to,
 void MoveBasic::goalCallback(const geometry_msgs::PoseStamped::ConstPtr &msg)
 {
     ROS_INFO("MoveBasic: Received simple goal");
+
     // send the goal to the action server
     move_base_msgs::MoveBaseActionGoal actionGoal;
     actionGoal.header.stamp = ros::Time::now();
     actionGoal.goal.target_pose = *msg;
-
     goalPub.publish(actionGoal);
+
+    // isNewGoalAvailable() needs to update on an actionServer
+    std::condition_variable newgoal_cv;
+    std::mutex cv_m;
+    std::unique_lock<std::mutex> newgoal_lk(cv_m);
+    auto now = std::chrono::system_clock::now();
+    auto timeout = std::chrono::milliseconds(50);
+    newgoal_cv.wait_until(newgoal_lk,
+            now + timeout,
+            [this](){return actionServer->isNewGoalAvailable();}
+    );
+
+    // If there is a new goal store it
+    if(actionServer-> isNewGoalAvailable()) {
+        tf2::fromMsg(msg->pose, nextGoalPose);
+        frameIdNext = msg->header.frame_id;
+        // Needed for RobotCommander
+        if (frameIdNext[0] == '/')
+            frameIdNext = frameIdNext.substr(1);
+
+        nextGoalAvailable = true;
+    }
 }
 
 
@@ -337,15 +340,9 @@ void MoveBasic::abortGoal(const std::string msg)
 void MoveBasic::executeAction(const move_base_msgs::MoveBaseGoalConstPtr& msg)
 {
     /*
-      Plan a path that involves rotating to face the goal, going straight towards it,
-      and then rotating for the final orientation.
-
       It is assumed that we are dealing with imperfect localization data:
          map->base_link is accurate but may be delayed and is at a slow rate
          odom->base_link is frequent, but drifts, particularly after rotating
-
-      To counter these issues, we plan in the map frame, and wait localizationLatency
-      after each step, and execute in the odom frame.
     */
 
     tf2::Transform goal;
@@ -356,47 +353,39 @@ void MoveBasic::executeAction(const move_base_msgs::MoveBaseGoalConstPtr& msg)
     if (frameId[0] == '/')
         frameId = frameId.substr(1);
 
+    if (frameId.compare(goalReachedFrameId) == 0) {
+        return;
+    }
+    goalReachedFrameId = frameId;
+
     double x, y, yaw;
     getPose(goal, x, y, yaw);
-
     ROS_INFO("MoveBasic: Received goal %f %f %f %s", x, y, rad2deg(yaw), frameId.c_str());
-
     if (std::isnan(yaw)) {
         abortGoal("MoveBasic: Aborting goal because an invalid orientation was specified");
         return;
     }
 
-    std::string planningFrame;
-    double goalYaw;
-
-    // The pose of the robot planning frame MUST be known initially, and may or may not
-    // be known after that.
-    // The pose of the robot in the driving frame MUST be known at all times.
-    // An empty planning frame means to use what ever frame the goal is specified in.
-    if (preferredPlanningFrame == "") {
-       planningFrame = frameId;
-       goalInPlanning = goal;
-       ROS_INFO("Planning in goal frame: %s\n", planningFrame.c_str());
-    }
-    else if (!transformPose(frameId, preferredPlanningFrame, goal, goalInPlanning)) {
-        ROS_WARN("MoveBasic: Will attempt to plan in %s frame", alternatePlanningFrame.c_str());
-        if (!transformPose(frameId, alternatePlanningFrame, goal,
-            goalInPlanning)) {
-            abortGoal("MoveBasic: No localization available for planning");
-            return;
-        }
-        planningFrame = alternatePlanningFrame;
-        goalYaw = yaw;
+    // Driving frame
+    std::string drivingFrame;
+    tf2::Transform goalInDriving;
+    tf2::Transform currentDrivingBase;
+    if (!getTransform(preferredDrivingFrame, baseFrame, currentDrivingBase)) {
+         ROS_WARN("MoveBasic: %s not available, attempting to drive using %s frame",
+                  preferredDrivingFrame.c_str(), alternateDrivingFrame.c_str());
+         if (!getTransform(alternateDrivingFrame,
+                           baseFrame, currentDrivingBase)) {
+             abortGoal("MoveBasic: Cannot determine robot pose in driving frame");
+             return;
+         }
+         else
+             drivingFrame = alternateDrivingFrame;
     }
     else {
-        planningFrame = preferredPlanningFrame;
+      drivingFrame = preferredDrivingFrame;
     }
 
-    getPose(goalInPlanning, x, y, goalYaw);
-    ROS_INFO("MoveBasic: Goal in %s  %f %f %f", planningFrame.c_str(),
-             x, y, rad2deg(goalYaw));
-
-    // publish our planned path
+    // Publish our planned path
     nav_msgs::Path path;
     geometry_msgs::PoseStamped p0, p1;
     path.header.frame_id = frameId;
@@ -407,7 +396,7 @@ void MoveBasic::executeAction(const move_base_msgs::MoveBaseGoalConstPtr& msg)
 
     tf2::Transform poseFrameId;
     if (!getTransform(baseFrame, frameId, poseFrameId)) {
-         abortGoal("MoveBasic: Cannot determine robot pose in goal frame(line 410)");
+         abortGoal("MoveBasic: Cannot determine robot pose in goal frame");
          return;
     }
     getPose(poseFrameId, x, y, yaw);
@@ -418,31 +407,12 @@ void MoveBasic::executeAction(const move_base_msgs::MoveBaseGoalConstPtr& msg)
 
     pathPub.publish(path);
 
-    std::string drivingFrame;
-    tf2::Transform goalInDriving;
-    tf2::Transform currentDrivingBase;
-    // Should be at time of goal message
-    if (!getTransform(preferredDrivingFrame, baseFrame, currentDrivingBase)) {
-         ROS_WARN("MoveBasic: %s not available, attempting to drive using %s frame",
-                  preferredDrivingFrame.c_str(), alternateDrivingFrame.c_str());
-         if (!getTransform(alternateDrivingFrame,
-                           baseFrame, currentDrivingBase)) {
-             abortGoal("MoveBasic: Cannot determine robot pose in driving frame(line 430)");
-             return;
-         }
-         else {
-             drivingFrame = alternateDrivingFrame;
-         }
-    }
-    else {
-      drivingFrame = preferredDrivingFrame;
-    }
 
+    // Current goal in driving frame
     if (!transformPose(frameId, drivingFrame, goal, goalInDriving)) {
-         abortGoal("MoveBasic: Cannot determine goal pose in driving frame(line 442)");
+         abortGoal("MoveBasic: Cannot determine goal pose in driving frame");
          return;
     }
-
     tf2::Transform goalInBase = currentDrivingBase * goalInDriving;
     {
        double x, y, yaw;
@@ -451,93 +421,26 @@ void MoveBasic::executeAction(const move_base_msgs::MoveBaseGoalConstPtr& msg)
              x, y, rad2deg(yaw));
     }
 
+    // Driving distance
     tf2::Vector3 linear = goalInBase.getOrigin();
-    linear.setZ(0);
-    double dist = linear.length();
-    bool reverseWithoutTurning =
-        (reverseWithoutTurningThreshold > dist && linear.x() < 0.0);
+    double requestedDistance = sqrt(linear.x() * linear.x() + linear.y() * linear.y());
 
-    // Initial rotation to face goal
-    for (int i=0; i<rotationAttempts; i++) {
-        tf2::Transform goalInBase;
-        if (!transformPose(frameId, baseFrame, goal, goalInBase)) {
-            ROS_WARN("MoveBasic: Cannot determine robot pose for rotation");
+    // Driving direction
+    bool reverseWithoutTurning = (reverseWithoutTurningThreshold > requestedDistance && linear.x() < 0.0);
+
+    // Send control commands
+    if (requestedDistance > minRequestDistance) {
+        if (!smoothControl(requestedDistance, reverseWithoutTurning, drivingFrame, goalInDriving))
             return;
-        }
-
-        if (dist > linearTolerance) {
-            double requestedYaw = atan2(linear.y(), linear.x());
-            ROS_INFO("REQUESTED YAW: %f", requestedYaw);
-            if (reverseWithoutTurning) {
-                if (requestedYaw > 0.0) {
-                    requestedYaw = -M_PI + requestedYaw;
-                }
-                else {
-                    requestedYaw = M_PI - requestedYaw;
-                }
-            }
-
-            if (std::abs(requestedYaw) < angularTolerance) {
-                break;
-            }
-            if (!rotate(requestedYaw, drivingFrame)) {
-                return;
-            }
-            sleep(localizationLatency);
-        }
     }
-
-    // Do linear portion of goal
-    ROS_INFO("MoveBasic: Requested distance %f", dist);
-
-    if (std::abs(dist) > linearTolerance) {
-        if (reverseWithoutTurning) {
-            dist = - dist;
-        }
-        if (!moveLinear(goalInDriving, planningFrame, drivingFrame)) {
-            return;
-        }
-        {
-            tf2::Transform poseFrameIdFinal;
-            if (!getTransform(baseFrame, frameId, poseFrameIdFinal)) {
-                 ROS_WARN("MoveBasic: Cannot determine robot pose in goal frame(line 502)");
-            }
-            tf2::Vector3 distTravelled = poseFrameIdFinal.getOrigin() -
-                                         poseFrameId.getOrigin();
-            ROS_DEBUG("MoveBasic: Travelled %f %f\n", distTravelled.x(), distTravelled.y());
-        }
-
-        sleep(localizationLatency);
+    else {
+        ROS_WARN("Requested distance is lower than the minimum distance threshold ( %f meters)", minRequestDistance);
+        abortGoal("MoveBasic: Aborting due to goal being already close enough.");
+        return;
     }
-
-    // Final rotation as specified in goal
-    if (!actionServer->isNewGoalAvailable()) {
-        tf2::Transform finalPose;
-        if (!getTransform(baseFrame, drivingFrame, finalPose)) {
-             abortGoal("MoveBasic: Cannot determine robot pose for final rotation");
-             return;
-        }
-
-        getPose(finalPose, x, y, yaw);
-        rotate(goalYaw - yaw, drivingFrame);
-    }
-/*
-    sleep(10);
-    // Final sanity check
-    {
-        tf2::Transform poseFrameIdFinal;
-        if (!getTransform(baseFrame, frameId, poseFrameIdFinal)) {
-             ROS_WARN("Cannot determine robot pose in goal frame");
-        }
-        tf2::Vector3 distTravelled = poseFrameIdFinal.getOrigin() -
-                                     poseFrameId.getOrigin();
-        ROS_DEBUG("Travelled %f %f\n", distTravelled.x(), distTravelled.y());
-    }
-*/
 
     actionServer->setSucceeded();
 }
-
 
 
 // Send a motion command
@@ -557,7 +460,6 @@ void MoveBasic::sendCmd(double angular, double linear)
 void MoveBasic::run()
 {
     ros::Rate r(20);
-    std_msgs::Float32 msg;
 
     while (ros::ok()) {
         ros::spinOnce();
@@ -578,312 +480,224 @@ void MoveBasic::run()
 }
 
 
-// Rotate relative to current orientation
+// Smooth control drive
 
-bool MoveBasic::rotate(double yaw, const std::string& drivingFrame)
+bool MoveBasic::smoothControl(double requestedDistance,
+                              bool reverseWithoutTurning,
+                              const std::string& drivingFrame,
+                              tf2::Transform& goalInDriving)
 {
-    ROS_INFO("MoveBasic: Requested rotation %f", rad2deg(yaw));
+        // Driving direction
+        bool forward = true;
 
-    tf2::Transform poseDriving;
-    if (!getTransform(baseFrame, drivingFrame, poseDriving)) {
-         abortGoal("MoveBasic: Cannot determine robot pose for rotation");
-         return false;
-    }
+        // For Abort check
+        ros::Time last = ros::Time::now();
+        ros::Duration abortTimeout(abortTimeoutSecs);
 
-    double x, y, currentYaw;
-    getPose(poseDriving, x, y, currentYaw);
-    double requestedYaw = currentYaw + yaw;
-    normalizeAngle(requestedYaw);
+        // For de/acceleration constraint
+        double previousLinearVelocity = 0.0;
+        double prevDistance = requestedDistance;
+        ros::Time previousTime = ros::Time::now();
 
-    bool done = false;
-    ros::Rate r(50);
+        // For lateral control
+        double lateralIntegral = 0.0;
+        double lateralError = 0.0;
+        double prevLateralError = 0.0;
+        double lateralDiff = 0.0;
 
-    int oscillations = 0;
-    double prevAngleRemaining = 0;
+        // For Obstacle Avoidance
+        bool waitingForObstacle = false;
+        int  waitingLoops = 0;
+        ros::Time obstacleTime;
 
-    while (!done && ros::ok()) {
-        ros::spinOnce();
-        r.sleep();
+        bool done = false;
+        ros::Rate r(50);
 
-	// TODO: Already defined?
-        // TODO: double x, y, currentYaw;
-        // TODO: tf2::Transform poseDriving;
-        if (!getTransform(baseFrame, drivingFrame, poseDriving)) {
-            abortGoal("MoveBasic: Cannot determine robot pose for rotation");
-            return false;
-        }
-        getPose(poseDriving, x, y, currentYaw);
+        while(!done && ros::ok()){
+            ros::spinOnce();
+            r.sleep();
 
-        double angleRemaining = requestedYaw - currentYaw;
-        normalizeAngle(angleRemaining);
-
-        double obstacle = collision_checker->obstacle_angle(angleRemaining > 0);
-        double remaining = std::min(std::abs(angleRemaining), std::abs(obstacle));
-        double speed = std::max(minAngularVelocity,
-            std::min(maxAngularVelocity,
-              std::sqrt(2.0 * angularAcceleration *
-                (remaining - angularTolerance))));
-
-        double angular_velocity = 0;
-
-        if (angleRemaining < 0.0) {
-            angular_velocity = -speed;
-        }
-        else {
-            angular_velocity = speed;
-        }
-
-        if (sign(prevAngleRemaining) != sign(angleRemaining)) {
-            oscillations++;
-        }
-        prevAngleRemaining = angleRemaining;
-
-        if (actionServer->isPreemptRequested()) {
-            ROS_INFO("MoveBasic: Stopping rotation due to preempt");
-            done = true;
-            angular_velocity = 0;
-        }
-
-        //ROS_INFO("%f %f %f", rad2deg(angleRemaining), angleRemaining, velocity);
-
-        if (std::abs(angleRemaining) < angularTolerance || oscillations > 2) {
-            angular_velocity = 0;
-            done = true;
-            ROS_INFO("MoveBasic: Done rotation, error %f degrees", rad2deg(angleRemaining));
-        }
-        sendCmd(angular_velocity, 0);
-    }
-    return done;
-}
-
-// Move forward specified distance
-
-bool MoveBasic::moveLinear(tf2::Transform& goalInDriving,
-                           const std::string& planningFrame,
-                           const std::string& drivingFrame)
-{
-    bool done = false;
-    ros::Rate r(50);
-
-    bool waitingForObstacle = false;
-    int  waitingLoops = 0;
-    double forwardObstacleThreshold = 1.5;  // if distance <  velocity times this we stop
-    ros::Time obstacleTime;
-
-    tf2::Transform poseDrivingInitial;
-    if (!getTransform(baseFrame, drivingFrame, poseDrivingInitial)) {
-         abortGoal("MoveBasic: Cannot determine robot pose for linear");
-         return false;
-    }
-
-    tf2::Vector3 linear = (poseDrivingInitial.getOrigin() -
-                           goalInDriving.getOrigin());
-    linear.setZ(0);
-    double requestedDistance = linear.length();
-
-    tf2::Transform poseDriving;
-    if (!getTransform(drivingFrame, baseFrame, poseDriving)) {
-         abortGoal("MoveBasic: Cannot determine robot pose for linear");
-         return false;
-    }
-
-    tf2::Transform goalInBase = poseDriving * goalInDriving;
-    tf2::Vector3 remaining = goalInBase.getOrigin();
-    bool forward = (remaining.x() > 0);
-
-    // For lateral control
-    double lateralIntegral = 0.0;
-    double lateralError = 0.0;
-    double prevLateralError = 0.0;
-    double lateralDiff = 0.0;
-    ros::Time sensorTime;
-
-    while (!done && ros::ok()) {
-        ros::spinOnce();
-        r.sleep();
-
-        // Try to update the goal in the driving frame. This might not work,
-        // for example if it was based on a fiducial which was no longer
-        // visible. However, if the goal was based up a fiducial, then it
-        // is likley that the estimate of our position relative to it
-        // will improve as we get closer
-        tf2::Transform T_planning_driving;
-        if (getTransform(planningFrame, drivingFrame, T_planning_driving)) {
-            goalInDriving = T_planning_driving * goalInPlanning;
-            double gx, gy, gyaw;
-            getPose(goalInDriving, gx, gy, gyaw);
-            ROS_DEBUG("Updated goal %f %f %f\n", gx, gy, gyaw);
-        }
-        else {
-            ROS_DEBUG("Could not update goal\n");
-        }
-
-        if (!getTransform("odom", baseFrame, poseDriving)) {
-             ROS_WARN("MoveBasic: Cannot determine robot pose for linear");
-             continue;
-        }
-        goalInBase = poseDriving * goalInDriving;
-        remaining = goalInBase.getOrigin();
-        double distRemaining = sqrt(remaining.x() * remaining.x() + remaining.y() * remaining.y());
-
-        tf2::Transform initialBaseToCurrent = poseDrivingInitial * poseDriving;
-        double cx, cy, cyaw;
-        getPose(initialBaseToCurrent, cx, cy, cyaw);
-
-        double distTravelled = std::abs(requestedDistance) - std::abs(distRemaining);
-
-
-        // stick to planned path
-        lateralError = sideRecoverWeight * remaining.y();
-     
-/*
-        Future enhancement: turn to avoid a forward obstacle
-
-        bool canTurn = std::abs(cyaw) <= maxTurn;
-        if (canTurn && forwardObstacleDist < 1.0) {
-            if (leftObstacleDist > rightObstacleDist) {
-               lateralError = lateralMaxRotation;
+            tf2::Transform poseDriving;
+            if (!getTransform(drivingFrame, baseFrame, poseDriving)) {
+                 ROS_WARN("MoveBasic: Cannot determine robot pose for driving");
+                 continue;
             }
-            else {
-               lateralError = -lateralMaxRotation;
+
+            // Current goal state in base frame
+            tf2::Transform goalInBase = poseDriving * goalInDriving;
+            tf2::Vector3 remaining = goalInBase.getOrigin();
+            double distRemaining = sqrt(remaining.x() * remaining.x() + remaining.y() * remaining.y());
+            ROS_INFO("distRemaining: %f", distRemaining);
+            double angleRemaining = atan2(remaining.y(), remaining.x());
+            normalizeAngle(angleRemaining);
+
+            // If the goal is right behing the robot, it drives backwards to it
+            if (reverseWithoutTurning) {
+                if (angleRemaining > 0.0)
+                    angleRemaining = -M_PI + angleRemaining;
+                else
+                    angleRemaining = M_PI - angleRemaining;
+                forward = false;
             }
-        }
-*/
-        if (std::abs(remaining.y()) >= maxLateralDev) {
-            abortGoal("MoveBasic: Aborting since max deviation reached");
-            sendCmd(0, 0);
-            return false;
-        }
 
-        // PID loop to control rotation to keep robot on path
-        double rotation = 0.0;
+            // Next goal state in base frame, if available
+            double angleToNextGoal;
+            double distanceToNextGoal;
+            if (nextGoalAvailable) {
+                tf2::Transform nextGoalInDriving;
+                // Next goal in driving frame
+                if (!transformPose(frameIdNext, drivingFrame, nextGoalPose, nextGoalInDriving)) {
+                     abortGoal("MoveBasic: Cannot determine next goal pose in driving frame");
+                     done = false;
+                     goto FinishWithStop;
+                }
+                tf2::Transform nextGoalInBase = poseDriving * nextGoalInDriving;
+                tf2::Vector3 nextRemaining = nextGoalInBase.getOrigin();
+                angleToNextGoal = atan2(nextRemaining.y(), nextRemaining.x());
+                normalizeAngle(angleToNextGoal);
+                distanceToNextGoal = sqrt(nextRemaining.x() * nextRemaining.x() + nextRemaining.y() * nextRemaining.y());
+            }
 
-        lateralDiff = lateralError - prevLateralError;
-        prevLateralError = lateralError;
 
-        lateralIntegral += lateralError;
+            // Control to reference pose //
 
-        rotation = (lateralKp * lateralError) + (lateralKi * lateralIntegral) +
-                   (lateralKd * lateralDiff);
+            // Rotational part
+            double pidAngularVelocity = 0.0;
+            lateralError = angleRecoverWeight * angleRemaining;
+            lateralDiff = lateralError - prevLateralError;
+            prevLateralError = lateralError;
+            lateralIntegral += lateralError;
+            pidAngularVelocity = (lateralKp * lateralError) + (lateralKi * lateralIntegral) +
+                       (lateralKd * lateralDiff);
 
-        // Clamp rotation
-        rotation = std::max(-lateralMaxRotation, std::min(lateralMaxRotation,
-                                                          rotation));
-	/*
-	// If goal passed, the orientation turns around
-	// TODO: Test it!
-	bool goal_passed = false;
-	double error_rotation = rotation - previousRotation;
-	if (error_rotation > 90 || error_rotation < 90) {
-		goal_passed = true;
-	}
-	*/
+            double obstacle = collision_checker->obstacle_angle(angleRemaining > 0);
+            double obstacleAngle = std::min(std::abs(angleRemaining), std::abs(obstacle));
+            double angularVelocity = std::max(-maxAngularVelocity,
+                                        std::min(maxAngularVelocity,
+                                        std::min(pidAngularVelocity, sqrt(2.0 * maxAngularAcceleration * obstacleAngle))));
 
-        // Limit angular deviation from planned path to prevent turning around
-        if (cyaw > maxAngularDev && rotation < 0) {
-            ROS_DEBUG("limit right\n");
-            rotation = 0;
-        }
-        else if (cyaw < -maxAngularDev && rotation > 0) {
-            ROS_DEBUG("limit left\n");
-            rotation = 0;
-        }
+            // Distance to obstacle
+            double obstacleDist = forwardObstacleDist;
+            if (requestedDistance < 0.0) { // Reverse
+                obstacleDist = collision_checker->obstacle_dist(false,
+                                                        leftObstacleDist,
+                                                        rightObstacleDist,
+                                                        forwardLeft,
+                                                        forwardRight);
+            }
+            ROS_DEBUG("MoveBasic: %f L %f, R %f\n",
+                    forwardObstacleDist, leftObstacleDist, rightObstacleDist);
 
-        ROS_DEBUG("MoveBasic: %f L %f, R %f %f %f %f %f %f\n",
-                  forwardObstacleDist, leftObstacleDist, rightObstacleDist,
-                  remaining.x(), remaining.y(), lateralError,
-                  rotation, rad2deg(cyaw));
+            // Turning Algorithm that calculates the maximum allowed speed when cornering in order not to slip or tip over
+            double maxTurnVelocity = sqrt(maxLateralDev * gravityConstant * maxIncline/(1-cos(angleRemaining/2)));
+            double linearVelocity = std::max(-maxLinearVelocity,
+                                        std::min(std::min(maxLinearVelocity,
+                                        std::min(std::min(velMult * distRemaining, maxTurnVelocity),
+                                        sqrt(2.0 * maxLinearAcceleration * obstacleDist))),
+                                        velMult * (previousLinearVelocity + 2.0 * maxLinearAcceleration * distRemaining)));
 
-        // Publish messages for PID tuning
-        geometry_msgs::Vector3 pid_debug;
-        pid_debug.x = remaining.x();
-        pid_debug.y = lateralError;
-        pid_debug.z = rotation;
-        errorPub.publish(pid_debug);
+            // In order to achieve smooth toggling between going linear and into the turn, minimum output velocity
+            // of the Turning Algorithm is calculated so that the linear velocity(going into the turn) does not get lower than that
+            if (nextGoalAvailable) {
+                double startTurnVelocity = sqrt(gravityConstant * maxIncline * maxLateralDev/(1-cos(angleToNextGoal/2)));
+                double nextGoalVelocity = velMult * distanceToNextGoal;
+                linearVelocity = std::min(nextGoalVelocity,
+                                    std::min(maxLinearVelocity,
+                                    std::max(linearVelocity, startTurnVelocity)));
+            }
 
-        double obstacleDist = forwardObstacleDist;
-        if (requestedDistance < 0.0) { // Reverse
-            obstacleDist = collision_checker->obstacle_dist(false,
-                                                            leftObstacleDist,
-                                                            rightObstacleDist,
-                                                            forwardLeft,
-                                                            forwardRight);
-        }
+            if (!forward)
+                linearVelocity = -linearVelocity;
 
-        double velocity = std::max(minLinearVelocity,
-            std::min(maxLinearVelocity, std::min(
-              std::sqrt(2.0 * linearAcceleration * std::abs(distTravelled)),
-              std::sqrt(0.5 * linearAcceleration *
-                 std::min(obstacleDist, distRemaining)))));
+            previousLinearVelocity = linearVelocity;
+            previousTime = ros::Time::now();
 
-        // Stop if there is an obstacle in the distance we would hit in given time
-        bool obstacleDetected = obstacleDist <= velocity * forwardObstacleThreshold;
-        if (obstacleDetected) {
-            velocity = 0;
-            if (!waitingForObstacle) {
-                ROS_INFO("MoveBasic: PAUSING for OBSTACLE");
-                obstacleTime = ros::Time::now();
-                waitingForObstacle = true;
+            // Send control command
+            sendCmd(angularVelocity, linearVelocity);
+
+
+            // Obstacle Avoidance //
+
+            // Stop if there is an obstacle in the distance we would hit in given time
+            bool obstacleDetected = (obstacleDist <= linearVelocity * forwardObstacleThreshold);
+            if (obstacleDetected) {
+                linearVelocity = 0;
+                if (!waitingForObstacle) {
+                    ROS_INFO("MoveBasic: PAUSING for OBSTACLE");
+                    obstacleTime = ros::Time::now();
+                    waitingForObstacle = true;
+                    waitingLoops = 0;
+                }
+                else {
+                    waitingLoops += 1;
+                    if ((waitingLoops % 10) == 1)
+                        ROS_INFO("MoveBasic: Still waiting for obstacle at %f meters!", obstacleDist);
+                    ros::Duration waitTime = ros::Time::now() - obstacleTime;
+                    if (waitTime.toSec() > obstacleWaitLimit) {
+                        abortGoal("MoveBasic: Aborting due to obstacle");
+                        done = false;
+                        goto FinishWithStop;
+                    }
+                }
+            }
+
+            if (waitingForObstacle && ! obstacleDetected) {
+                ROS_INFO("MoveBasic: Resuming after obstacle has gone");
+                waitingForObstacle = false;
                 waitingLoops = 0;
             }
-            else {
-                waitingLoops += 1;
-                if ((waitingLoops % 10) == 1) {
-                    ROS_INFO("MoveBasic: Still waiting for obstacle at %f meters!", obstacleDist);
-                }
-                ros::Duration waitTime = ros::Time::now() - obstacleTime;
-                if (waitTime.toSec() > obstacleWaitLimit) {
-                    abortGoal("MoveBasic: Aborting due to obstacle");
-                    sendCmd(0, 0);
-                    return false;
+
+
+            // Abort Checks //
+
+            if (distRemaining < prevDistance) {
+                prevDistance = distRemaining;
+                if (ros::Time::now() - last > abortTimeout) {
+                        abortGoal("MoveBasic: No progress towards goal for longer than timeout.");
+                        done = false;
+                        goto FinishWithStop;
                 }
             }
-        }
 
-        if (waitingForObstacle && ! obstacleDetected) {
-            ROS_INFO("MoveBasic: Resuming after obstacle has gone");
-            waitingForObstacle = false;
-            waitingLoops = 0;
-            // start off again smoothly
-            requestedDistance = distRemaining;
-            distTravelled = 0.0;
-        }
+            if (actionServer->isPreemptRequested()) {
+                ROS_INFO("MoveBasic: Stopping due to preempt request");
+                done = true;
+                goto FinishWithStop;
+            }
 
-        if (actionServer->isPreemptRequested()) {
-            ROS_INFO("MoveBasic: Stopping move due to preempt");
-            done = true;
-            velocity = 0;
-        }
 
-	// TODO: Motor controller speed command noise "???"
-        double velMult = 1.0; // TODO: Experimental variable
-	double MOTOR_CONTROLLER_NOISE = 0.001;
-	if (velMult*distRemaining < MOTOR_CONTROLLER_NOISE) { // Check if velocity input lower than the noise level
-		if (!(actionServer->isNewGoalAvailable()) && (distRemaining < linearTolerance)) { // Checks if in tolerance range
-			velocity = 0;
-			done = true;
-        		ROS_INFO("MoveBasic: Done linear, error %f, %f meters", remaining.x(), remaining.y());
-		}
-		/*
-		else if (actionServer->isNewGoalAvailable() && (distRemaining < linearTolerance || goal_passed)) {
-			// Keep the velocity
-			done = true;
-        		ROS_INFO("MoveBasic: Done linear, error %f, %f meters", remaining.x(), remaining.y());
-		}
-		*/
-		else {
-			velocity = 0;
-			done = false;
-			abortGoal("MoveBasic: Aborting due to linear error");
-		}
-	}
+            // Check navigation complete //
 
-        if (!forward) {
-            velocity = -velocity;
+            // Checks if intermediate reference pose reached
+            if (distRemaining < linearTolerance && nextGoalAvailable) { // Checks if in tolerance range
+                ROS_INFO("MoveBasic: Goal reached - ERROR: x: %f meters, y: %f meters, yaw: %f degrees", remaining.x(), remaining.y(), rad2deg(angleRemaining));
+                nextGoalAvailable = false;
+                done = true;
+                goto FinishWithoutStop;
+            }
+
+            // Checks if final reference pose reached
+            if ((std::abs(linearVelocity) < velThreshold) && !nextGoalAvailable && !waitingForObstacle && (prevDistance+linearTolerance < requestedDistance)) {
+                ROS_DEBUG("Remaining velocity: %f", linearVelocity);
+                sendCmd(0, 0);
+                nextGoalAvailable = false;
+                if (distRemaining < linearTolerance) { // Checks if in tolerance range
+                    ROS_INFO("MoveBasic: Goal reached - ERROR: x: %f meters, y: %f meters, yaw: %f degrees", remaining.x(), remaining.y(), rad2deg(angleRemaining));
+                    done = true;
+                }
+                else {
+                    abortGoal("MoveBasic: Aborting due to missing the goal");
+                    done = false;
+                }
+                goto FinishWithStop;
+            }
         }
-        sendCmd(rotation, velMult * velocity);
-    }
-    return done;
+   FinishWithStop:
+        sendCmd(0, 0);
+
+   FinishWithoutStop:
+
+   return done;
 }
 
 


### PR DESCRIPTION
This branch was created from the branch **navigation_tests**, because it rely on most of the stuff I did there.
The code in branch (**navigation_tests**) implemented some features to the achieving the reference pose and abort checks, which are also added in this new branch **move-advanced**.
The code in this branch(**move-advanced**) implements smooth cornering and if the linear velocity in a turn is to high, it reduces it to prevent the robot slipping or even tipping over. 
Depending upon which algorithm smooth-cornering or combination of rotate+moveLinear we choose, the corresponding PR will be removed.