### PR TITLE
Fix extremely bad bug that incorrectly exited the linear move 

### DIFF
--- a/src/move_basic.cpp
+++ b/src/move_basic.cpp
@@ -487,7 +487,7 @@ void MoveBasic::executeAction(const move_base_msgs::MoveBaseGoalConstPtr& msg)
     }
 
     // Do linear portion of goal
-    ROS_INFO("MoveBasic: Requested distance %f", dist);
+    ROS_INFO("MoveBasic: Requested distance %f with linear tolerance of %f", dist,linearTolerance);
 
     if (std::abs(dist) > linearTolerance) {
         if (reverseWithoutTurning) {
@@ -844,11 +844,11 @@ bool MoveBasic::moveLinear(tf2::Transform& goalInDriving,
             velocity = 0;
         }
 
-        if (abs(remaining.x()) < linearTolerance) {
+        if (std::abs(remaining.x()) < linearTolerance) {
             velocity = 0;
             done = true;
-            ROS_INFO("MoveBasic: Done linear, error %f, %f meters",
-                     remaining.x(), remaining.y());
+            ROS_INFO("MoveBasic: Done linear, error in X %f, Y %f meters. Tol %f ",
+                     remaining.x(), remaining.y(), linearTolerance);
         }
         if (!forward) {
             velocity = -velocity;


### PR DESCRIPTION
I was having a heck of a time with move basic exiting without moving forward at all.

Issue is the  abs(remaining.x()) was used when we must use   std::abs(remaining.x())

Without this fix move basic is close to useless !         This is an urgent fix!

I don't know what is on our images.  The image may be ok, don't know.