### PR TITLE
Level up perfomance of LiDAR storage & processing

### DIFF
--- a/include/move_basic/collision_checker.h
+++ b/include/move_basic/collision_checker.h
@@ -73,7 +73,7 @@ class CollisionChecker
    float degrees(float radians) const;
 
 public:
-   // Note that we take in refrences to tf_buffer and op, we expect these to outlive 
+   // Note that we take in refrences to tf_buffer and op, we expect these to outlive
    // the useful life of this class, if they don't then you have a big issue.
    //
    // We don't store the NodeHandle, so that doesn't apply to it.
@@ -85,7 +85,7 @@ public:
 
    // return distance in radians to closest obstacle
    float obstacle_angle(bool left);
-   
+
    float obstacle_arc_angle(double linear, double angular);
 
    double min_side_dist;
@@ -93,4 +93,3 @@ public:
 };
 
 #endif
-

--- a/include/move_basic/obstacle_points.h
+++ b/include/move_basic/obstacle_points.h
@@ -43,6 +43,25 @@
 #include <sensor_msgs/Range.h>
 #include <sensor_msgs/LaserScan.h>
 
+// lidar sensor
+class LidarSensor
+{
+public:
+    std::string frame_id;
+    double angle_increment;
+    double min_range;
+    double max_range;
+    double min_angle;
+    double max_angle;
+    LidarSensor() {};
+    void reset(const std::string & _frame,
+               const int _increment,
+               const double & _min_range,
+               const double & _max_range,
+               const double & _min_angle,
+               const double & _max_angle);
+};
+
 // a single sensor with current obstacles
 class RangeSensor
 {
@@ -81,19 +100,23 @@ private:
   };
 
   std::mutex points_mutex;
-   
+
   std::string baseFrame;
 
+  LidarSensor lidar;
   std::map<std::string, RangeSensor> sensors;
   ros::Subscriber sonar_sub;
   ros::Subscriber scan_sub;
   tf2_ros::Buffer& tf_buffer;
-   
+
   bool have_lidar;
   tf2::Vector3 lidar_origin;
   tf2::Vector3 lidar_normal;
   std::vector<PolarLine> lidar_points;
   ros::Time lidar_stamp;
+
+  // Sine / Cosine LookUp Tables
+  std::vector<float> sinLUT, cosLUT;
 
   // Manually added points, used for unit testing things that
   // use ObstaclePoints without having to go through ROS messages
@@ -111,7 +134,7 @@ public:
    *
    */
   std::vector<tf2::Vector3> get_points(ros::Duration max_age);
- 
+
   /*
    * Returns a vector of lines (expressed as a pair of 2 points).
    * The lines are based on the end of the sonar cones, filtered
@@ -121,7 +144,7 @@ public:
   typedef std::pair<tf2::Vector3, tf2::Vector3> Line;
   std::vector<Line> get_lines(ros::Duration max_age);
 
-  // Used for unit testing things that use ObstaclePoints 
+  // Used for unit testing things that use ObstaclePoints
   // without having to go through ROS messages
   void add_test_point(tf2::Vector3 p);
   void clear_test_points();
@@ -129,4 +152,3 @@ public:
 };
 
 #endif
-

--- a/src/collision_checker.cpp
+++ b/src/collision_checker.cpp
@@ -72,7 +72,7 @@
 #include "move_basic/collision_checker.h"
 
 
-CollisionChecker::CollisionChecker(ros::NodeHandle& nh, tf2_ros::Buffer &tf_buffer, 
+CollisionChecker::CollisionChecker(ros::NodeHandle& nh, tf2_ros::Buffer &tf_buffer,
 		                   ObstaclePoints& op) : tf_buffer(tf_buffer),
 	                                                 ob_points(op)
 {
@@ -257,7 +257,7 @@ float CollisionChecker::obstacle_dist(bool forward,
     fl.setY(min_dist_left);
     fr.setX(robot_front_length);
     fr.setY(min_dist_right);
-    
+
     auto pts = ob_points.get_points(ros::Duration(max_age));
     for (const auto& p : pts) {
        float y = p.y();
@@ -288,7 +288,7 @@ float CollisionChecker::obstacle_dist(bool forward,
 
     draw_line(tf2::Vector3(robot_front_length, -min_dist_right, 0),
               tf2::Vector3(robot_front_length + 2, -min_dist_right, 0), 0, 0.5, 0, 20003);
- 
+
     // Blue
     draw_line(tf2::Vector3(robot_front_length, min_dist_left, 0),
               tf2::Vector3(fl.x(), fl.y(), 0), 0, 0, 1, 30000);
@@ -473,12 +473,12 @@ float CollisionChecker::obstacle_arc_angle(double linear, double angular) {
     const auto point_of_rotation = tf2::Vector3(0, (left) ? radius : -radius, 0);
 
     // Critical robot corners relative to point of rotation
-    const auto outer_point = tf2::Vector3(-robot_back_length, 
+    const auto outer_point = tf2::Vector3(-robot_back_length,
             (left) ? -robot_width: robot_width, 0) - point_of_rotation;
-    const auto inner_point = tf2::Vector3(robot_front_length, 
+    const auto inner_point = tf2::Vector3(robot_front_length,
             (left) ? robot_width: -robot_width, 0) - point_of_rotation;
 
-    // Critical robot points in polar (r^2, theta) form relative to center 
+    // Critical robot points in polar (r^2, theta) form relative to center
     // of rotation
     const float outer_radius_sq = outer_point.length2();
     const float outer_theta = std::atan2(outer_point.y(), outer_point.x());
@@ -509,10 +509,10 @@ float CollisionChecker::obstacle_arc_angle(double linear, double angular) {
     float closest_angle = M_PI;
     const auto points = ob_points.get_points(ros::Duration(max_age));
     for (const auto& p : points) {
-        // Trasform the obstacle point into the coordiate system with the 
+        // Trasform the obstacle point into the coordiate system with the
         // point of rotation at the origin, with the same orientation as base_link
         const tf2::Vector3 p_in_rot = p - point_of_rotation;
-        // Radius for polar coordinates around center of rotation 
+        // Radius for polar coordinates around center of rotation
         const float p_radius_sq = p_in_rot.length2();
 
         if(p_radius_sq < outer_radius_sq && p_radius_sq > inner_radius_sq) {


### PR DESCRIPTION
This PR improves LiDAR data storage in two ways:
- std::vector function reserve() is used, which allocates enough memory in the Free-Store so there is no need for resizing and copying all of the data of the std::vector to the new memory location when this happens
- Lookup Tables for Sine and Cosine of theta(LiDAR angle) are used, because std::sin() and std::cos() are quite costly operation that where repeatedly used in our callbacks.  

I did profile the code myself on my PC and experienced 30-50% less time consumed on these for loops. To give you a sense in seconds - Firstly the for loop took ~140 microseconds, afterwards it took ~60 microseconds. 