### PR TITLE
Rotation after runaway abort

### DIFF
--- a/src/move_basic.cpp
+++ b/src/move_basic.cpp
@@ -754,10 +754,10 @@ bool MoveBasic::moveLinear(tf2::Transform& goalInDriving,
         /* Since we are dealing with imperfect localization we should make
          * sure we are at least runawayTimeout driving away from the goal*/
         double angleRemaining = std::atan2(remaining.y(), remaining.x());
-        if (std::cos(angleRemaining) < 0) { // 0
+        if (std::cos(angleRemaining) < 0) {
             if (ros::Time::now() - last > runawayTimeout) {
                 ROS_INFO("MoveBasic: Moving away from goal");
-                sendCmd(rotation, 0);
+                sendCmd(0, 0);
                 return true;
             }
         }

--- a/src/move_basic.cpp
+++ b/src/move_basic.cpp
@@ -754,11 +754,11 @@ bool MoveBasic::moveLinear(tf2::Transform& goalInDriving,
         /* Since we are dealing with imperfect localization we should make
          * sure we are at least runawayTimeout driving away from the goal*/
         double angleRemaining = std::atan2(remaining.y(), remaining.x());
-        if (std::cos(angleRemaining) < 0) {
+        if (std::cos(angleRemaining) < 0) { // 0
             if (ros::Time::now() - last > runawayTimeout) {
-                abortGoal("MoveBasic: Moving away from goal");
-                sendCmd(0, 0);
-                return false;
+                ROS_INFO("MoveBasic: Moving away from goal");
+                sendCmd(rotation, 0);
+                return true;
             }
         }
         else {


### PR DESCRIPTION
Just a simple alteration that only aborts linear speed when detecting runaway and still does the rotation. I'm not sure about the general applicability but I guess it's likely that the abort will kick in when the robot is just past the goal, at which point it would make sense to accept it as "done" perhaps.

One of our clients seems to be getting these aborts at roughly 30-50% of the goals sent, which is odd and should be looked into more in the future, but this'll hopefully solve some of their issues for the time being.